### PR TITLE
New fixed-point theorem to reason about time

### DIFF
--- a/probability/probabilistic_relations/Examples/utp_prob_rel_lattice_coin.thy
+++ b/probability/probabilistic_relations/Examples/utp_prob_rel_lattice_coin.thy
@@ -1,15 +1,16 @@
-section \<open> (Parametric) Coin flip \<close>
+section \<open> (Parametric) Coin flip_t \<close>
 
 theory utp_prob_rel_lattice_coin
   imports 
     "UTP_prob_relations.utp_prob_rel" 
+    "HOL-Analysis.Infinite_Set_Sum"
 begin 
 
 unbundle UTP_Syntax
 
 declare [[show_types]]
 
-subsection \<open> Single coin flip without time\<close>
+subsection \<open> Single coin flip_t without time\<close>
 
 datatype Tcoin = chead | ctail
 thm "Tcoin.exhaust"
@@ -471,7 +472,7 @@ proof -
     by force
 qed
 
-subsection \<open> Single coin flip (variable probability)\<close>
+subsection \<open> Single coin flip_t (variable probability)\<close>
 definition cpflip :: "ureal \<Rightarrow> cstate prhfun" where
 "cpflip p = if\<^sub>p \<guillemotleft>p\<guillemotright> then (c := chead) else (c := ctail)"
 
@@ -656,39 +657,44 @@ lemma cpflip_loop:
   using cpH_is_fp apply blast
   by simp
 
-(*
-subsection \<open> Coin flip with time \<close>
-alphabet coin_state = time +
+
+subsection \<open> Coin flip_t with time \<close>
+alphabet coin_t_state = time +
   coin :: Tcoin
 
-thm "coin_state.simps"
-definition flip:: "coin_state prhfun" where
-"flip = (prfun_of_rvfun (coin \<^bold>\<U> {chead, ctail}))"
+thm "coin_t_state.simps"
+definition flip_t:: "coin_t_state prhfun" where
+"flip_t = (prfun_of_rvfun (coin \<^bold>\<U> {chead, ctail}))"
 
-definition flip_loop where
-"flip_loop = while\<^sub>p\<^sub>t (coin\<^sup>< = ctail)\<^sub>e do flip od"
+definition flip_t_loop where
+"flip_t_loop = while\<^sub>p\<^sub>t (coin\<^sup>< = ctail)\<^sub>e do flip_t od"
 
-definition H:: "coin_state \<times> coin_state \<Rightarrow> \<real>" where 
-"H = (\<lbrakk>coin\<^sup>> = chead \<and> $t\<^sup>> \<ge> $t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e * (1/2)^(($t\<^sup>> - $t\<^sup>< - 1)) * (1/2))\<^sub>e"
+(*
+definition Ht:: "coin_t_state rvhfun" where 
+"Ht = (\<lbrakk>coin\<^sup>> = chead \<and> $t\<^sup>> \<ge> $t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e * (1/2)^(($t\<^sup>> - $t\<^sup>< - 1)) * (1/2))\<^sub>e"
+*)
+definition Ht:: "coin_t_state rvhfun" where 
+"Ht = (\<lbrakk>coin\<^sup>< = ctail\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>coin\<^sup>> = chead\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk> $t\<^sup>> \<ge> $t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e * (1/2)^(($t\<^sup>> - $t\<^sup>< - 1)) * (1/2) + 
+      \<lbrakk>\<not>coin\<^sup>< = ctail\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>coin\<^sup>> = chead\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>$t\<^sup>> = $t\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e )\<^sub>e"
 
-lemma flip_is_dist: "is_final_distribution (rvfun_of_prfun flip)"
-  apply (simp add: flip_def)
+lemma flip_is_dist: "is_final_distribution (rvfun_of_prfun flip_t)"
+  apply (simp add: flip_t_def)
   apply (subst rvfun_uniform_dist_inverse)
   apply (simp)+
   using rvfun_uniform_dist_is_dist
   by (metis coin_vwb_lens finite.emptyI finite.insertI insert_not_empty)
 
-lemma flip_altdef: "rvfun_of_prfun flip = (\<lbrakk>\<Squnion> v \<in> {ctail, chead}. coin := \<guillemotleft>v\<guillemotright>\<rbrakk>\<^sub>\<I>\<^sub>e / 2)\<^sub>e"
-  apply (simp add: flip_def)
+lemma flip_t_altdef: "rvfun_of_prfun flip_t = (\<lbrakk>\<Squnion> v \<in> {ctail, chead}. coin := \<guillemotleft>v\<guillemotright>\<rbrakk>\<^sub>\<I>\<^sub>e / 2)\<^sub>e"
+  apply (simp add: flip_t_def)
   apply (subst prfun_uniform_dist_altdef')
   apply simp+
   by (pred_auto)
 
-definition flip_t_alt :: "coin_state rvhfun" where
+definition flip_t_alt :: "coin_t_state rvhfun" where
 "flip_t_alt \<equiv> (\<lbrakk>coin\<^sup>> \<in> {chead, ctail} \<and> $t\<^sup>> = $t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e / 2)\<^sub>e"
 
-lemma flip_t: "(Pt flip) = prfun_of_rvfun flip_t_alt"
-  apply (simp add: flip_def Pt_def flip_t_alt_def)
+lemma flip_t: "(Pt flip_t) = prfun_of_rvfun flip_t_alt"
+  apply (simp add: flip_t_def Pt_def flip_t_alt_def)
   apply (simp add: prfun_uniform_dist_left)
   apply (simp add: pfun_defs)
   apply (simp add: rvfun_assignment_inverse)
@@ -698,9 +704,23 @@ lemma flip_t: "(Pt flip) = prfun_of_rvfun flip_t_alt"
   by (expr_auto add: rel assigns_r_def)
 
 lemma flip_t_set_eq: 
-  "\<forall>t. {s::coin_state. (coin\<^sub>v s = chead \<or> coin\<^sub>v s = ctail) \<and> t\<^sub>v s = Suc t} = 
-  {\<lparr>t\<^sub>v = Suc t, coin\<^sub>v = chead\<rparr>, \<lparr>t\<^sub>v = Suc t, coin\<^sub>v = ctail\<rparr>}"
+  "\<forall>t. {s::coin_t_state. (coin\<^sub>v s = chead \<or> coin\<^sub>v s = ctail) \<and> t\<^sub>v s = Suc t} = 
+       {\<lparr>t\<^sub>v = Suc t, coin\<^sub>v = chead\<rparr>, \<lparr>t\<^sub>v = Suc t, coin\<^sub>v = ctail\<rparr>}"
   by (auto)
+
+lemma flip_t_set_eq': 
+  "\<forall>t. {s::coin_t_state. coin\<^sub>v s = ctail \<and> s \<in> {v\<^sub>0::coin_t_state. t\<^sub>v v\<^sub>0 = Suc t}} = 
+       {\<lparr>t\<^sub>v = Suc t, coin\<^sub>v = ctail\<rparr>}"
+  by auto
+
+lemma flip_t_set_eq'': "\<forall>t. {s::coin_t_state. coin\<^sub>v s = chead \<and> t\<^sub>v s = t} = {\<lparr>t\<^sub>v = t, coin\<^sub>v = chead\<rparr>}"
+  by auto
+
+lemma flip_t_set_eq''': 
+  "\<forall>t. ((\<lambda>n::\<nat>. \<lparr>t\<^sub>v = Suc t + n, coin\<^sub>v = chead\<rparr>) ` UNIV) = {v\<^sub>0. coin\<^sub>v v\<^sub>0 = chead \<and> Suc t \<le> t\<^sub>v v\<^sub>0}"
+    apply auto
+    by (smt (verit, ccfv_threshold) UNIV_I add_Suc coin_t_state.surjective image_iff nat_le_iff_add old.unit.exhaust)
+
 
 lemma flip_t_is_dist: "is_final_distribution flip_t_alt"
   apply (simp add: dist_defs flip_t_alt_def)
@@ -712,151 +732,45 @@ lemma flip_t_is_dist: "is_final_distribution flip_t_alt"
   using flip_t_set_eq apply (metis finite.simps)
   using flip_t_set_eq 
   by (smt (verit, best) Collect_cong One_nat_def Suc_1 Tcoin.distinct(1) card.empty card.insert 
-      coin_state.ext_inject field_sum_of_halves finite.emptyI finite.insertI insert_absorb 
+      coin_t_state.ext_inject field_sum_of_halves finite.emptyI finite.insertI insert_absorb 
       insert_not_empty of_nat_1 of_nat_add one_add_one singletonD time.ext_inject)
 
-lemma iterate_tflip_bottom_simp:
-  shows "iter\<^sub>p 0 (coin\<^sup>< = ctail)\<^sub>e (Pt flip) 0\<^sub>p = 0\<^sub>p"
-        "iter\<^sub>p (Suc 0) (coinc\<^sup>< = ctail)\<^sub>e (Pt flip) 0\<^sub>p = (\<lbrakk>$coin\<^sup>< = chead \<and> $coin\<^sup>> = chead \<and> $t\<^sup>> = $t\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e)"
-        "iter\<^sub>p (n+2) (coin\<^sup>< = ctail)\<^sub>e (Pt flip) 0\<^sub>p = 
-              (\<lbrakk>$coin\<^sup>< = chead \<and> $coin\<^sup>> = chead \<and> $t\<^sup>> = $t\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e + 
-               \<lbrakk>$coin\<^sup>< = ctail \<and> $coin\<^sup>> = chead \<and> $t\<^sup>> \<ge> $t\<^sup>< + 1 \<and> $t\<^sup>> \<le> $t\<^sup>< + \<guillemotleft>n\<guillemotright> + 1\<rbrakk>\<^sub>\<I>\<^sub>e 
-                * (\<Sum>i\<in>{1..\<guillemotleft>n+1\<guillemotright>}. (1/2)^i))\<^sub>e"
-  sorry
-  (*apply (auto)
-  apply (simp add: loopfunc_def)
-  apply (simp add: prfun_zero_right')
-  apply (simp add: pfun_defs)
-  apply (subst rvfun_skip_inverse)
-  apply (subst ureal_zero)
-  apply (simp add: ureal_defs)
-  apply (subst fun_eq_iff)
-  apply (expr_auto)
-  apply (meson Tcoin.exhaust)
-  apply (induct_tac n)
-  apply (simp)
-  apply (simp add: loopfunc_def)
-  apply (simp add: prfun_zero_right')
-  apply (simp add: pfun_defs)
-  apply (subst rvfun_skip_inverse)+
-  apply (subst ureal_zero)
-  apply (subst rvfun_pcond_inverse)
-  apply (metis ureal_is_prob ureal_zero)
-  apply (simp add: rvfun_skip_f_is_prob)
-  apply (subst cflip_altdef)
-  apply (subst rvfun_inverse)
-  apply (simp add: dist_defs)
-  apply (expr_auto)
-  apply (simp add: infsum_nonneg iverson_bracket_def)
-  apply (pred_auto)
-  apply (simp add: cstate_UNIV_set)
-  apply (smt (verit, ccfv_SIG) prfun_in_0_1' rvfun_skip_inverse)
-  apply (simp add: prfun_of_rvfun_def)
-  apply (expr_auto)
-  apply (simp add: real2ureal_def)
-  apply (simp add: infsum_0 iverson_bracket_def real2ureal_def rel_skip)
-  apply (meson Tcoin.exhaust)
-  apply (simp add: cstate_UNIV_set)
-  apply (pred_auto)
-  apply (simp add: real2ureal_def)
-  using real2ureal_def apply blast+
-  apply (simp add: cstate_UNIV_set)
-  apply (pred_auto)
-  using real2ureal_def apply blast+
-  apply (simp add: cstate_UNIV_set)
-  apply (pred_auto)
-  using real2ureal_def apply blast+
-  (* *)
-  apply (simp)
-  apply (subst loopfunc_def)
-  apply (subst pseqcomp_def)
-  apply (subst pcond_def)
-  apply (subst cflip_altdef)
-  apply (subst rvfun_inverse)
-  apply (simp add: dist_defs)
-  apply (expr_auto)
-  apply (simp add: infsum_nonneg  prfun_in_0_1')
-  apply (pred_auto)
-  apply (simp add: cstate_UNIV_set)
-  apply (simp add: rvfun_of_prfun_def)
-  apply (auto)
-  apply (smt (verit, best) field_sum_of_halves ureal_upper_bound)
-  using ureal_upper_bound apply blast
-  apply (subst prfun_of_rvfun_def)
-  apply (subst rvfun_of_prfun_def)+
-  apply (expr_auto)
-  apply (simp add: cstate_UNIV_set)
-  apply (pred_auto)
-  defer
-  apply (subst prfun_skip_id)
-  apply (simp add: one_ureal.rep_eq real2ureal_def ureal2real_def)
-  using Tcoin.exhaust apply blast
-  apply (metis (full_types) Tcoin.exhaust cstate.select_convs(1) ereal_real o_def prfun_skip_not_id real2ureal_def ureal2real_def zero_ereal_def zero_ureal.rep_eq)
-  apply (subst infsum_0)
-  apply (subst ureal_defs)
-  apply (smt (verit, best) divide_eq_0_iff ereal_max min.absorb2 min.commute mult_eq_0_iff o_apply real_of_ereal_0 ureal2ereal_inverse ureal2real_def zero_ereal_def zero_less_one_ereal zero_ureal.rep_eq)
-  using real2ureal_def apply presburger
-  using Tcoin.exhaust apply blast
-  apply (subst infsum_0)
-  apply (subst ureal_defs)
-  apply (smt (verit, best) divide_eq_0_iff ereal_max min.absorb2 min.commute mult_eq_0_iff o_apply real_of_ereal_0 ureal2ereal_inverse ureal2real_def zero_ereal_def zero_less_one_ereal zero_ureal.rep_eq)
-  using real2ureal_def apply blast
-  apply (metis (full_types) Tcoin.exhaust cstate.ext_inject o_def prfun_skip_not_id real2ureal_def real_of_ereal_0 ureal2real_def zero_ureal.rep_eq)
-  apply (subst ureal2real_1_2)
-  apply (subst sum_1_2)
-  apply (subst sum_geometric_series_ureal)
-  apply (subst sum_geometric_series')
-  apply (subst ureal_defs)+
-proof -
-  fix n
-  have f1: "((1::\<real>) / (2::\<real>) + ((1::\<real>) - (1::\<real>) / (2::\<real>) ^ (n + (1::\<nat>))) / (2::\<real>)) = 
-        ((1::\<real>) - (1::\<real>) / (2::\<real>) ^ (n + 2))"
-    by (simp add: add.assoc diff_divide_distrib)
-  have f2: "((3::\<real>) * ((1::\<real>) / (2::\<real>)) ^ n / (4::\<real>) + ((1::\<real>) - (1::\<real>) / (2::\<real>) ^ n)) =  
-          ((1::\<real>) - (1::\<real>) / (2::\<real>) ^ (n+2))"
-    apply (auto)
-    by (simp add: power_one_over)
-  show "ereal2ureal' (min (max (0::ereal) (ereal ((1::\<real>) / (2::\<real>) + ((1::\<real>) - (1::\<real>) / (2::\<real>) ^ (n + (1::\<nat>))) / (2::\<real>)))) (1::ereal)) =
-       ereal2ureal' (min (max (0::ereal) (ereal ((3::\<real>) * ((1::\<real>) / (2::\<real>)) ^ n / (4::\<real>) + ((1::\<real>) - (1::\<real>) / (2::\<real>) ^ n)))) (1::ereal))"
-    using f1 f2 by presburger
-qed
-*)
-
-lemma H_is_dist: "is_final_distribution H"
+(*
+lemma H_is_dist: "is_final_distribution Ht"
   apply (simp add: dist_defs H_def)
   apply (simp add: expr_defs)
   apply (auto)
   apply (smt (verit, best) field_sum_of_halves power_le_one)
   apply (simp add: lens_defs)
 proof -
-  fix s\<^sub>1::"coin_state"
-  let ?lhs = "(\<Sum>\<^sub>\<infinity>s::coin_state.
+  fix s\<^sub>1::"coin_t_state"
+  let ?lhs = "(\<Sum>\<^sub>\<infinity>s::coin_t_state.
           (if coin\<^sub>v s = chead \<and> Suc (t\<^sub>v s\<^sub>1) \<le> t\<^sub>v s then 1::\<real> else (0::\<real>)) *
           ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v s - Suc (t\<^sub>v s\<^sub>1)) / (2::\<real>))"
-  let ?set = "{s::coin_state. coin\<^sub>v s = chead \<and> Suc (t\<^sub>v s\<^sub>1) \<le> t\<^sub>v s}"
+  let ?set = "{s::coin_t_state. coin\<^sub>v s = chead \<and> Suc (t\<^sub>v s\<^sub>1) \<le> t\<^sub>v s}"
 
   (*
   thm "infsum_reindex"
   have "(\<Sum>\<^sub>\<infinity>t::nat \<in> {t. t \<ge> Suc (t\<^sub>v s\<^sub>1)}. ((1::\<real>) / (2::\<real>)) ^ (t - Suc (t\<^sub>v s\<^sub>1) + 1)) = 1"
-    apply (subst infsum_reindex[where h = "\<lambda>s::coin_state. t\<^sub>v s" and A = "?set"])
+    apply (subst infsum_reindex[where h = "\<lambda>s::coin_t_state. t\<^sub>v s" and A = "?set"])
 *)
-  have f1: "?lhs = (\<Sum>\<^sub>\<infinity>s::coin_state \<in> ?set \<union> -?set.
+  have f1: "?lhs = (\<Sum>\<^sub>\<infinity>s::coin_t_state \<in> ?set \<union> -?set.
           (if coin\<^sub>v s = chead \<and> Suc (t\<^sub>v s\<^sub>1) \<le> t\<^sub>v s then 1::\<real> else (0::\<real>)) *
           ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v s - Suc (t\<^sub>v s\<^sub>1)) / (2::\<real>))"
     by auto
-  moreover have "... = (\<Sum>\<^sub>\<infinity>s::coin_state \<in> ?set.
+  moreover have "... = (\<Sum>\<^sub>\<infinity>s::coin_t_state \<in> ?set.
           (if coin\<^sub>v s = chead \<and> Suc (t\<^sub>v s\<^sub>1) \<le> t\<^sub>v s then 1::\<real> else (0::\<real>)) *
           ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v s - Suc (t\<^sub>v s\<^sub>1)) / (2::\<real>))"
     apply (rule infsum_cong_neutral)
     apply force
     apply simp
     by blast
-  moreover have "... = (\<Sum>\<^sub>\<infinity>s::coin_state \<in> ?set. ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v s - Suc (t\<^sub>v s\<^sub>1)) / (2::\<real>))"
+  moreover have "... = (\<Sum>\<^sub>\<infinity>s::coin_t_state \<in> ?set. ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v s - Suc (t\<^sub>v s\<^sub>1)) / (2::\<real>))"
     by (smt (verit) infsum_cong mem_Collect_eq mult_cancel_right2)
-  moreover have "... = (\<Sum>\<^sub>\<infinity>s::coin_state \<in> ?set. ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v s - Suc (t\<^sub>v s\<^sub>1) + 1))"
+  moreover have "... = (\<Sum>\<^sub>\<infinity>s::coin_t_state \<in> ?set. ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v s - Suc (t\<^sub>v s\<^sub>1) + 1))"
     by auto
   moreover have "... = (\<Sum>\<^sub>\<infinity>t::nat \<in> {t. t \<ge> Suc (t\<^sub>v s\<^sub>1)}. ((1::\<real>) / (2::\<real>)) ^ (t - Suc (t\<^sub>v s\<^sub>1) + 1))"
-    apply (subst infsum_reindex_bij_betw[symmetric, where g = "\<lambda>s::coin_state. t\<^sub>v s" and A = "?set"])
+    apply (subst infsum_reindex_bij_betw[symmetric, where g = "\<lambda>s::coin_t_state. t\<^sub>v s" and A = "?set"])
     apply (simp add: bij_betw_def)
     apply (rule conjI)
     apply (simp add: inj_on_def)
@@ -888,89 +802,474 @@ proof -
   ultimately show "?lhs = (1::\<real>)"
     by presburger
 qed
-
-lemma "finite {s::coin_state \<times> coin_state. \<exists>n::\<nat>. \<not> iterate\<^sub>t n (coin\<^sup>< = ctail)\<^sub>e flip 0\<^sub>p s = (0::ureal)}"
-proof -
-  have f0: "iterate\<^sub>t (n + 2) (coin\<^sup>< = ctail)\<^sub>e flip 0\<^sub>p = 
-          (\<lbrakk>$coin\<^sup>< = chead \<and> $coin\<^sup>> = chead \<and> $t\<^sup>> = $t\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e + 
-           \<lbrakk>$coin\<^sup>< = ctail \<and> $coin\<^sup>> = chead \<and> $t\<^sup>> \<ge> $t\<^sup>< + 1 \<and> $t\<^sup>> \<le> $t\<^sup>< + \<guillemotleft>n\<guillemotright> + 1\<rbrakk>\<^sub>\<I>\<^sub>e 
-           * (\<Sum>i\<in>{1..\<guillemotleft>n+1\<guillemotright>}. (1/2)^i))\<^sub>e"
-    by (simp only: iterate_tflip_bottom_simp)
-
-  have "\<not> (iterate\<^sub>t (n + 2) (coin\<^sup>< = ctail)\<^sub>e flip 0\<^sub>p (\<lparr>t\<^sub>v = tt, coin\<^sub>v = chead\<rparr>, \<lparr>t\<^sub>v = tt, coin\<^sub>v = chead\<rparr>) 
-        = (0::ureal))"
-    apply (subst f0)
-    apply (expr_auto)
-    using one_ereal_def one_ureal_def by auto
-
-  have "(iterate\<^sub>t (n + 2) (coin\<^sup>< = ctail)\<^sub>e flip 0\<^sub>p (\<lparr>t\<^sub>v = x, coin\<^sub>v = ctail\<rparr>, \<lparr>t\<^sub>v = y, coin\<^sub>v = ctail\<rparr>) 
-        = (0::ureal))"
-    apply (subst f0)
-    apply (expr_auto)
-    by (simp add: zero_ereal_def zero_ureal_def)
-
-  have "{s::coin_state \<times> coin_state. \<exists>n::\<nat>. \<not> iterate\<^sub>t (n) (coin\<^sup>< = ctail)\<^sub>e flip 0\<^sub>p s = (0::ureal)}
-    = {s::coin_state \<times> coin_state. \<exists>n::\<nat>. \<not> iterate\<^sub>t (n+2) (coin\<^sup>< = ctail)\<^sub>e flip 0\<^sub>p s = (0::ureal)}"
-    apply (subst set_eq_iff)
-    apply (rule allI)+
-    apply (rule iffI)
-    apply (simp add: expr_defs lens_defs)
-    using iterate_increasing2
-    apply (smt (z3) Suc_eq_plus1 flip_t flip_t_is_dist is_final_distribution_prob is_final_prob_prob 
-        iterate_increasing1 le_funD nle_le pzero_def rvfun_inverse ureal_bottom_least' iterate.simps(2))
-    apply (simp add: expr_defs lens_defs)
-    by (metis utp_prob_rel_lattice.iterate.simps(2))
-
-  text \<open> From the formula above and below, we can see this set is not finite because there are infinite 
-    number of states to satisfy @{text "t\<^sub>v (fst s) = t\<^sub>v (snd s)"} where @{text "t"} could be any natural number. \<close>
-  have "{s::coin_state \<times> coin_state. \<exists>n::\<nat>. \<not> iterate\<^sub>t (n+2) (coin\<^sup>< = ctail)\<^sub>e flip 0\<^sub>p s = (0::ureal)}
-    = {s::coin_state \<times> coin_state. (coin\<^sub>v (fst s) = chead \<and> coin\<^sub>v (snd s) = chead \<and> t\<^sub>v (fst s) = t\<^sub>v (snd s))
-      \<or> (coin\<^sub>v (fst s) = ctail \<and> coin\<^sub>v (snd s) = chead \<and> t\<^sub>v (snd s) \<ge> t\<^sub>v (fst s) + 1)}"
-    apply (simp only: iterate_tflip_bottom_simp)
-    apply (subst set_eq_iff)
-    apply (simp add: expr_defs lens_defs)
-    apply (rule allI)+
-    apply (rule conjI)
-    apply (metis one_ereal_def one_ureal_def zero_neq_one)
-    apply (rule impI)
-    apply (rule iffI)
-    apply (metis zero_ereal_def zero_ureal_def)
-    apply (auto)
-    apply (smt (verit, best) Suc_eq_plus1 add_Suc_shift field_sum_of_halves nat_le_iff_add power_one_over real2eureal_inverse sum_1_2 sum_geometric_series sum_geometric_series_ureal ureal_lower_bound zero_ereal_def zero_ureal_def)
-    by (smt (verit, best) Suc_eq_plus1 add_Suc_shift field_sum_of_halves nat_le_iff_add power_one_over real2eureal_inverse sum_1_2 sum_geometric_series sum_geometric_series_ureal ureal_lower_bound zero_ereal_def zero_ureal_def)
-
-  have "finite {s::coin_state \<times> coin_state. \<exists>n::\<nat>. \<not> iterate\<^sub>t (n+2) (coin\<^sup>< = ctail)\<^sub>e flip 0\<^sub>p s = (0::ureal)}"
-    apply (simp only: iterate_tflip_bottom_simp)
-  qed 
-
-lemma "flip_loop = H"
-  apply (simp add: flip_loop_def H_def)
-  apply (simp add: ptwhile_def)
-  apply (subst sup_continuous_lfp_iteration)
-  apply (metis flip_t flip_t_is_dist is_dist_def is_final_prob_prob rvfun_inverse)
-  apply (simp)
-  apply (subst rvfun_inverse)
-  apply (simp add: is_prob_def iverson_bracket_def)
-  using H_is_dist H_def 
-  apply (simp add: dist_defs expr_defs, auto)
-  apply (simp add: )
-  apply (simp add: pseqcomp_def)
-  apply (subst rvfun_seqcomp_inverse)
-  apply (simp add: flip_is_dist)
-  using ureal_is_prob apply blast
-  apply (subst rvfun_seqcomp_is_dist)
-  apply (simp add: flip_is_dist)
-  apply (expr_auto)
-  apply (simp add: passigns_def rvfun_assignment_inverse rvfun_assignment_is_dist)
-  apply (simp)
-  apply (simp add: pfun_defs)
-  apply (simp add: flip_altdef)
-  apply (expr_auto)
-  apply (subst rvfun_inverse)
-  apply (simp add: is_prob_def)
-   apply (rel_simp)
-  sorry
-
-lemma "H ; ($t\<^sup><)\<^sub>e = "
 *)
+
+lemma Ht_is_fp: "\<F> (coin\<^sup>< = ctail)\<^sub>e (Pt flip_t) (prfun_of_rvfun (Ht)) = prfun_of_rvfun (Ht)"
+  apply (simp add: Ht_def loopfunc_def)
+  apply (simp add: pfun_defs flip_t)
+  apply (subst flip_t_alt_def)
+  apply (subst rvfun_skip_inverse)
+  apply (subst rvfun_skip\<^sub>_f_simp)
+  apply (subst rvfun_seqcomp_inverse)
+  using flip_t_alt_def flip_t_is_dist rvfun_inverse rvfun_prob_sum1_summable'(1) apply force
+  using ureal_is_prob apply blast
+  apply (subst rvfun_inverse)
+  apply (expr_auto add: dist_defs)
+  apply (subst rvfun_inverse)
+  apply (expr_auto add: dist_defs)
+  apply (smt (verit, del_insts) One_nat_def add.commute plus_1_eq_Suc power_0 power_le_one_iff power_one_over power_one_right sum_1_2 sum_geometric_series')
+  apply (expr_auto add: prfun_of_rvfun_def skip_def)
+  using Tcoin.exhaust apply blast
+  using Tcoin.exhaust apply blast
+proof -
+  fix t t\<^sub>v'
+  assume a1: "Suc t \<le> t\<^sub>v'"
+  let ?f1 = "\<lambda>v\<^sub>0::coin_t_state. (if (coin\<^sub>v v\<^sub>0 = chead \<or> coin\<^sub>v v\<^sub>0 = ctail) \<and> t\<^sub>v v\<^sub>0 = Suc t then 1::\<real> else (0::\<real>))"
+  let ?f2 = "\<lambda>v\<^sub>0::coin_t_state. ((if coin\<^sub>v v\<^sub>0 = ctail then 1::\<real> else (0::\<real>)) * (if Suc (t\<^sub>v v\<^sub>0) \<le> t\<^sub>v' then 1::\<real> else (0::\<real>)) *
+            ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v' - Suc (t\<^sub>v v\<^sub>0)) / (2::\<real>) +
+            (if \<not> coin\<^sub>v v\<^sub>0 = ctail then 1::\<real> else (0::\<real>)) * (if t\<^sub>v' = t\<^sub>v v\<^sub>0 then 1::\<real> else (0::\<real>)))"
+  have set_eq_1: "{s::coin_t_state. coin\<^sub>v s = ctail \<and> t\<^sub>v s = Suc t \<and> Suc (t\<^sub>v s) \<le> t\<^sub>v'} = 
+        (if Suc (Suc t) \<le> t\<^sub>v' then {\<lparr>t\<^sub>v = Suc t, coin\<^sub>v = ctail\<rparr>} else {})"
+    by auto
+
+  have set_eq_2: "{s::coin_t_state. coin\<^sub>v s = chead \<and> t\<^sub>v' = t\<^sub>v s \<and> t\<^sub>v s = Suc t} = 
+        (if (Suc t) = t\<^sub>v' then {\<lparr>t\<^sub>v = Suc t, coin\<^sub>v = chead\<rparr>} else {})"
+    apply (simp)
+    apply (rule impI)
+    apply (subst set_eq_iff)
+    by (smt (verit, best) coin_t_state.equality coin_t_state.select_convs(1) mem_Collect_eq old.unit.exhaust singleton_iff time.select_convs(1))
+  
+  have "(\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. ?f1 v\<^sub>0 * ?f2 v\<^sub>0 / (2::\<real>)) =
+        (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. (if coin\<^sub>v v\<^sub>0 = ctail \<and> t\<^sub>v v\<^sub>0 = Suc t \<and> Suc (t\<^sub>v v\<^sub>0) \<le> t\<^sub>v' then 1 else 0) * 
+            ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v' - Suc (t\<^sub>v v\<^sub>0)) / (2::\<real>) / 2  + 
+           (if coin\<^sub>v v\<^sub>0 = chead \<and> t\<^sub>v'  = t\<^sub>v v\<^sub>0 \<and> t\<^sub>v v\<^sub>0 = Suc t then 1 else 0) / 2)"
+    apply (rule infsum_cong)
+    by (auto)
+  also have "... = (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. (if coin\<^sub>v v\<^sub>0 = ctail \<and> t\<^sub>v v\<^sub>0 = Suc t \<and> Suc (t\<^sub>v v\<^sub>0) \<le> t\<^sub>v' then 
+                (((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v' - Suc (Suc t)) / (2::\<real>) / 2) else 0) + 
+           (if coin\<^sub>v v\<^sub>0 = chead \<and> t\<^sub>v'  = t\<^sub>v v\<^sub>0 \<and> t\<^sub>v v\<^sub>0 = Suc t then 1/2 else 0))"
+    apply (rule infsum_cong)
+    by (auto)
+  also have "... = (((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v' - Suc t) / (2::\<real>))"
+    apply (subst infsum_add)
+    apply (rule infsum_constant_finite_states_summable)
+    apply (simp add: set_eq_1)
+    apply (rule infsum_constant_finite_states_summable)
+    apply (smt (verit, best) finite.emptyI finite.intros(2) flip_t_set_eq mem_Collect_eq rev_finite_subset subset_eq)
+    apply (subst infsum_constant_finite_states)
+    apply (simp add: set_eq_1)
+    apply (subst infsum_constant_finite_states)
+    apply (simp add: set_eq_2)
+    apply (simp add: set_eq_1 set_eq_2)
+    by (smt (verit, ccfv_threshold) Suc_diff_le a1 add.commute diff_Suc_Suc divide_divide_eq_left le_antisym not_less_eq_eq plus_1_eq_Suc power_Suc2 power_one_over sum_1_2 sum_geometric_series')
+  then show "real2ureal
+        (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. ?f1 v\<^sub>0 * ?f2 v\<^sub>0 / (2::\<real>)) =
+       real2ureal (((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v' - Suc t) / (2::\<real>))"
+    using calculation by presburger    
+next
+  fix t t\<^sub>v'
+  assume a1: "\<not> Suc t \<le> t\<^sub>v'"
+
+  show "real2ureal
+        (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state.
+           (if (coin\<^sub>v v\<^sub>0 = chead \<or> coin\<^sub>v v\<^sub>0 = ctail) \<and> t\<^sub>v v\<^sub>0 = Suc t then 1::\<real> else (0::\<real>)) *
+           ((if coin\<^sub>v v\<^sub>0 = ctail then 1::\<real> else (0::\<real>)) * (if Suc (t\<^sub>v v\<^sub>0) \<le> t\<^sub>v' then 1::\<real> else (0::\<real>)) *
+            ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v' - Suc (t\<^sub>v v\<^sub>0)) /
+            (2::\<real>) +
+            (if \<not> coin\<^sub>v v\<^sub>0 = ctail then 1::\<real> else (0::\<real>)) * (if t\<^sub>v' = t\<^sub>v v\<^sub>0 then 1::\<real> else (0::\<real>))) /
+           (2::\<real>)) = real2ureal (0::\<real>)"
+    apply (subst infsum_0)
+    using a1 apply force
+    by simp
+qed
+
+lemma Pt_flip_finite: "\<forall>s. finite {s'::coin_t_state. (0::ureal) < Pt flip_t (s, s')}"
+proof
+  fix s 
+  show "finite {s'::coin_t_state. (0::ureal) < Pt flip_t (s, s')} "
+    apply (simp add: flip_t)
+    apply (simp add: rvfun_ge_zero)
+    apply (simp add: flip_t_alt_def)
+    apply (pred_auto)
+    by (simp add: flip_t_set_eq)
+qed
+
+(* * \<lbrakk>$t\<^sup>> = $t\<^sup>< + 1 + \<guillemotleft>n\<guillemotright>\<rbrakk>\<^sub>\<I>\<^sub>e  *)
+(*
+[coin'=ctail]*[t'=t+1]/2 + [coin'=chead]*[t'=t+1]/2
+  iterdiff (n+1) (coin\<^sup>< = ctail)\<^sub>e (Pt flip_t) 1\<^sub>p 
+= [coin=ctail] * (
+    ([coin'=ctail]*[t'=t+1]/2 + [coin'=chead]*[t'=t+1]/2) ; 
+    (iterdiff (n+1) (coin\<^sup>< = ctail)\<^sub>e (Pt flip_t) 1\<^sub>p)
+  ) + [\<not>coin' = ctail] * 0
+= [coin=ctail] * (
+    ([coin'=ctail]*[t'=t+1]/2 + [coin'=chead]*[t'=t+1]/2) ; 
+    [coin=ctail]*[t'=t+n]*(1/2)^n
+  )
+ = [coin=ctail] * [t'=t+n+1]*(1/2)^(n+1)
+*)
+lemma flip_iterdiff_simp:
+  shows "(iterdiff 0 (coin\<^sup>< = ctail)\<^sub>e (Pt flip_t) 1\<^sub>p) = 1\<^sub>p"
+        "(iterdiff (n+1) (coin\<^sup>< = ctail)\<^sub>e (Pt flip_t) 1\<^sub>p) = 
+            prfun_of_rvfun ((\<lbrakk>coin\<^sup>< = ctail\<rbrakk>\<^sub>\<I>\<^sub>e * (1/2)^\<guillemotleft>n\<guillemotright>)\<^sub>e)"
+proof -
+  show "(iterdiff 0 (coin\<^sup>< = ctail)\<^sub>e (Pt flip_t) 1\<^sub>p) = 1\<^sub>p"
+    by (auto)
+
+  show "(iterdiff (n+1) (coin\<^sup>< = ctail)\<^sub>e (Pt flip_t) 1\<^sub>p) = 
+            prfun_of_rvfun ((\<lbrakk>coin\<^sup>< = ctail\<rbrakk>\<^sub>\<I>\<^sub>e * (1/2)^\<guillemotleft>n\<guillemotright>)\<^sub>e)"
+    apply (induction n)
+    apply (simp add: pfun_defs)
+    apply (subst flip_t)
+    apply (subst ureal_zero)
+    apply (subst ureal_one)
+    apply (subst rvfun_seqcomp_inverse)
+    apply (simp add: flip_t_is_dist rvfun_inverse rvfun_prob_sum1_summable'(1))
+    apply (metis ureal_is_prob ureal_one)
+    apply (subst rvfun_inverse)
+    apply (simp add: flip_t_is_dist rvfun_prob_sum1_summable'(1))
+    apply (rule HOL.arg_cong[where f="prfun_of_rvfun"])
+    apply (expr_auto add: rel assigns_r_def)
+    apply (simp add: flip_t_alt_def)
+    apply (pred_auto)
+    apply (subst infsum_cdiv_left)
+    apply (rule infsum_constant_finite_states_summable)
+    apply (simp add: flip_t_set_eq)
+    apply (subst infsum_constant_finite_states)
+    apply (simp add: flip_t_set_eq)
+     apply (simp add: flip_t_set_eq)
+    apply (simp only: add_Suc)
+    apply (simp only: iterdiff.simps(2))
+    apply (simp only: pcond_def)
+    apply (simp only: pseqcomp_def)
+    apply (subst rvfun_seqcomp_inverse)
+    apply (simp add: flip_t flip_t_is_dist rvfun_inverse rvfun_prob_sum1_summable'(1))
+    apply (simp add: ureal_is_prob)
+    apply (simp add: prfun_of_rvfun_def)
+    apply (subst rvfun_inverse)
+    apply (expr_auto add: dist_defs)
+    apply (simp add: power_le_one)
+    apply (subst flip_t)
+    apply (expr_auto add: rel assigns_r_def)  
+    defer
+    apply (simp add: pfun_defs)
+    apply (subst ureal_zero)
+    apply simp
+    apply (subst rvfun_inverse)
+    using flip_t_is_dist rvfun_prob_sum1_summable'(1) apply blast
+    apply (simp add: flip_t_alt_def)
+    apply (expr_auto add: rel assigns_r_def)
+  proof -
+    fix n t
+    let ?lhs = "(\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state.
+           (if (coin\<^sub>v v\<^sub>0 = chead \<or> coin\<^sub>v v\<^sub>0 = ctail) \<and> t\<^sub>v v\<^sub>0 = Suc t then 1::\<real> else (0::\<real>)) *
+           ((if coin\<^sub>v v\<^sub>0 = ctail then 1::\<real> else (0::\<real>)) * ((1::\<real>) / (2::\<real>)) ^ n) /
+           (2::\<real>))"
+    have "?lhs = (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state \<in> {v\<^sub>0. t\<^sub>v v\<^sub>0 = Suc t}.
+           (if coin\<^sub>v v\<^sub>0 = ctail then ((1::\<real>) / (2::\<real>)) ^ n / 2 else (0::\<real>)))"
+      apply (rule infsum_cong_neutral)
+      apply blast
+      apply auto[1]
+      by simp
+    also have "... = (((1::\<real>) / (2::\<real>)) ^ n / (2::\<real>))"
+      apply (subst infsum_constant_finite_states_subset)
+      apply (smt (verit, del_insts) Collect_mono finite.emptyI finite_insert flip_t_set_eq mem_Collect_eq rev_finite_subset)
+      apply (simp only: flip_t_set_eq')
+      by simp
+
+    then show "real2ureal ?lhs = real2ureal (((1::\<real>) / (2::\<real>)) ^ n / (2::\<real>))"
+      using calculation by presburger
+  qed
+qed
+
+lemma flip_iterdiff_tendsto_0:
+  "\<forall>s. (\<lambda>n::\<nat>. ureal2real (iterdiff n (coin\<^sup>< = ctail)\<^sub>e (Pt flip_t) 1\<^sub>p s)) \<longlonglongrightarrow> (0::\<real>)"
+proof 
+  fix s
+  have "(\<lambda>n::\<nat>. ureal2real (iterdiff (n+1) (coin\<^sup>< = ctail)\<^sub>e (Pt flip_t) 1\<^sub>p s)) \<longlonglongrightarrow> (0::\<real>)"
+    apply (subst flip_iterdiff_simp)
+    apply (simp add: prfun_of_rvfun_def)
+    apply (expr_auto)
+    apply (subst real2ureal_inverse)
+    apply (simp)
+    apply (simp add: power_le_one)
+    apply (simp add: LIMSEQ_realpow_zero)
+    apply (subst real2ureal_inverse)
+    by (simp)+
+  then show "(\<lambda>n::\<nat>. ureal2real (iterdiff n (coin\<^sup>< = ctail)\<^sub>e (Pt flip_t) 1\<^sub>p s)) \<longlonglongrightarrow> (0::\<real>)"
+    by (rule LIMSEQ_offset[where k = 1])
+qed
+
+lemma flip_t_loop: "flip_t_loop = prfun_of_rvfun Ht"
+  apply (simp add: flip_t_loop_def ptwhile_def)
+  apply (subst unique_fixed_point_lfp_gfp_finite_final'[where fp = "prfun_of_rvfun Ht"])
+  apply (simp add: flip_t flip_t_is_dist rvfun_inverse rvfun_prob_sum1_summable'(1))
+  using Pt_flip_finite apply blast
+  using flip_iterdiff_tendsto_0 apply (simp)
+  using Ht_is_fp apply blast
+  by simp
+
+lemma summable_n_2_power_n: 
+  "summable (\<lambda>n::\<nat>. (n / (2::\<real>)^n))" (is "summable ?f")
+  (* n:           0, 1,   2,   3,   4 *)
+  (*              0, 1/2, 2/4, 3/8, 4/16 *)
+  (* (n+1)/(2*n): x, 1,   3/4, 4/6, 5/8, ... *)
+  apply (subst summable_ratio_test[where c="3/4" and N="3"])
+  apply auto
+proof -
+  fix n::\<nat>
+  assume a1: "3 \<le> n"
+  have f1: "((1::\<real>) + real n) / ((2::\<real>) * (2::\<real>) ^ n) = ((n+1) / (2* n)) * (?f n)"
+    using a1 by auto
+  have f2: "((1::\<real>) + real n) / 1 \<le> (3::\<real>) * real n / ((2::\<real>))"
+    using a1 by force
+  have f3: "((1::\<real>) + real n) / ((2::\<real>) * (2::\<real>) ^ n) \<le> (3::\<real>) * real n / (2) / ((2::\<real>) * (2::\<real>) ^ n)"
+    apply (subst divide_right_mono[where c="((2::\<real>) * (2::\<real>) ^ n)"])
+    using f2 apply force
+    apply force
+    by simp
+  show "((1::\<real>) + real n) / ((2::\<real>) * (2::\<real>) ^ n) \<le> (3::\<real>) * real n / ((4::\<real>) * (2::\<real>) ^ n)"
+    apply (simp only: f1)
+    apply (auto)
+    using f3 by force
+qed
+
+lemma summable_2_power_n: "summable (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n / (2::\<real>))"
+  apply (rule summable_divide)
+  apply (rule summable_geometric)
+  by simp
+
+(*
+lemma summable_n_a_power_n: 
+  assumes "a \<ge> 2"
+  shows "summable (\<lambda>n::\<nat>. (n / (a::\<real>)^n))" (is "summable ?f")
+  (* n:           0, 1,   2,      3,    4 *)
+  (*              0, 1/a, 2/a^2, 3/a^3, 4/a^4 *)
+  (* (n+1)/(a*n): x, 2/a, 3/a*2, 4/a*3, 5/a*4, ... *)
+  apply (subst summable_ratio_test[where c="3/4" and N="3"])
+  apply auto
+proof -
+  fix n::\<nat>
+  assume a1: "3 \<le> n"
+  have f0: "\<bar>a * a ^ n\<bar> = a * a ^ n"
+    using assms by auto
+  have f1: "\<bar>a ^ n\<bar> = a ^ n"
+    using assms by auto
+  have f1: "((1::\<real>) + real n) / ((a::\<real>) * (a::\<real>) ^ n) = ((n+1) / (a* n)) * (?f n)"
+    using a1 by auto
+  have f2: "((1::\<real>) + real n) / 1 \<le> (3::\<real>) * real n / (4/a)"
+    apply auto
+  have f3: "((1::\<real>) + real n) / ((2::\<real>) * (2::\<real>) ^ n) \<le> (3::\<real>) * real n / (2) / ((2::\<real>) * (2::\<real>) ^ n)"
+    apply (subst divide_right_mono[where c="((2::\<real>) * (2::\<real>) ^ n)"])
+    using f2 apply force
+    apply force
+    by simp
+  show "((1::\<real>) + real n) / \<bar>a * a ^ n\<bar> \<le> (3::\<real>) * real n / ((4::\<real>) * \<bar>a ^ n\<bar>)"
+    apply (simp only: f0)
+    apply (simp only: f1)
+    apply (auto)
+    using f3 by force
+qed
+*)
+
+subsubsection \<open> Termination and average termination time \<close>
+lemma coin_flip_t_termination_prob: "Ht ; \<lbrakk>coin\<^sup>< = chead\<rbrakk>\<^sub>\<I>\<^sub>e = (1)\<^sub>e"
+  apply (simp add: Ht_def)
+apply (expr_auto)
+proof -
+  fix t coin
+  let ?lhs_f = "\<lambda>v\<^sub>0. (if coin\<^sub>v v\<^sub>0 = chead then 1::\<real> else (0::\<real>))"
+  let ?lhs_f2 = "\<lambda>v\<^sub>0. (if t\<^sub>v v\<^sub>0 = t then 1::\<real> else (0::\<real>))"
+  let ?lhs = "(\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. ?lhs_f v\<^sub>0 * ?lhs_f2 v\<^sub>0 * ?lhs_f v\<^sub>0 )"
+  have "?lhs = (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. if coin\<^sub>v v\<^sub>0 = chead \<and> t\<^sub>v v\<^sub>0 = t then 1::\<real> else (0::\<real>))"
+    apply (rule infsum_cong)
+    by (auto)
+  also have "... = 1"
+    apply (subst infsum_constant_finite_states)
+    by (simp add: flip_t_set_eq'')+
+  then show "?lhs = (1::\<real>)"
+    using calculation by presburger
+next
+  fix t
+  let ?lhs_f = "\<lambda>v\<^sub>0. (if coin\<^sub>v v\<^sub>0 = chead then 1::\<real> else (0::\<real>))"
+  let ?lhs_f2 = "\<lambda>v\<^sub>0. (if Suc t \<le> t\<^sub>v v\<^sub>0 then 1::\<real> else (0::\<real>))"
+  let ?lhs = "(\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. ?lhs_f v\<^sub>0 * ?lhs_f2 v\<^sub>0 *((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v v\<^sub>0 - Suc t) * ?lhs_f v\<^sub>0 / 2)"
+
+  have reindex: "infsum (\<lambda>v\<^sub>0::coin_t_state. ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v v\<^sub>0 - Suc t) / (2::\<real>))
+    ((\<lambda>n::\<nat>. \<lparr>t\<^sub>v = Suc t + n, coin\<^sub>v = chead\<rparr>) ` UNIV)
+    = infsum (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n / (2::\<real>)) UNIV"
+    apply (subst infsum_reindex)
+    apply (simp add: inj_def)
+    by (simp add: infsum_cong)
+
+  have set_eq: "((\<lambda>n::\<nat>. \<lparr>t\<^sub>v = Suc t + n, coin\<^sub>v = chead\<rparr>) ` UNIV) = {v\<^sub>0. coin\<^sub>v v\<^sub>0 = chead \<and> Suc t \<le> t\<^sub>v v\<^sub>0}"
+    apply auto
+    by (smt (verit, ccfv_threshold) UNIV_I add_Suc coin_t_state.surjective image_iff nat_le_iff_add old.unit.exhaust)
+
+  have "?lhs = (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. if coin\<^sub>v v\<^sub>0 = chead \<and> Suc t \<le> t\<^sub>v v\<^sub>0 then (((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v v\<^sub>0 - Suc t)/2) else (0::\<real>))"
+    apply (rule infsum_cong)
+    by (auto)
+  also have "... = (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state \<in> {v\<^sub>0. coin\<^sub>v v\<^sub>0 = chead \<and> Suc t \<le> t\<^sub>v v\<^sub>0}.
+       ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v v\<^sub>0 - Suc t) / (2::\<real>))"
+    apply (rule infsum_cong_neutral)
+    by (auto)
+  also have "... = infsum (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n / (2::\<real>)) UNIV"
+    using reindex using set_eq by auto
+  thm "geometric_sum"
+  thm "eventually_sequentially"
+  also have "... = 1"
+    apply (subst infsetsum_infsum[symmetric])
+    apply (simp add: abs_summable_on_nat_iff')
+    apply (subst infsetsum_nat)
+    apply (simp add: abs_summable_on_nat_iff')
+    apply auto
+    using power_half_series sums_unique by fastforce
+  then show "?lhs = (1::\<real>)"
+    using calculation by presburger
+qed
+
+lemma coin_flip_t_expected_termination_time: "Ht ; (\<guillemotleft>real\<guillemotright> (t\<^sup><))\<^sub>e = 
+      (\<lbrakk>coin\<^sup>< = ctail\<rbrakk>\<^sub>\<I>\<^sub>e * (t\<^sup>< + 2)  + \<lbrakk>\<not>coin\<^sup>< = ctail\<rbrakk>\<^sub>\<I>\<^sub>e * t\<^sup>< )\<^sub>e"
+  apply (pred_auto add: Ht_def)
+proof -
+  fix t coint
+  have "(\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state.
+          (if coin\<^sub>v v\<^sub>0 = chead then 1::\<real> else (0::\<real>)) * (if t\<^sub>v v\<^sub>0 = t then 1::\<real> else (0::\<real>)) * real (t\<^sub>v v\<^sub>0)) 
+    = (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. (if coin\<^sub>v v\<^sub>0 = chead \<and> t\<^sub>v v\<^sub>0 = t then real (t) else (0::\<real>)))"
+    apply (rule infsum_cong)
+    by (auto)
+  also have "... = real t"
+    apply (subst infsum_constant_finite_states)
+    apply (simp add: flip_t_set_eq'')
+    by (simp add: flip_t_set_eq'')
+  also show "(\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state.
+          (if coin\<^sub>v v\<^sub>0 = chead then 1::\<real> else (0::\<real>)) * (if t\<^sub>v v\<^sub>0 = t then 1::\<real> else (0::\<real>)) * real (t\<^sub>v v\<^sub>0)) =
+       real t"
+    using calculation by blast
+next
+  fix t
+  let ?f = "(\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ (n) * ((real t + real n)))"
+  have reindex: "infsum (\<lambda>v\<^sub>0::coin_t_state. ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v v\<^sub>0 - Suc t) * real (t\<^sub>v v\<^sub>0) / (2::\<real>))
+    ((\<lambda>n::\<nat>. \<lparr>t\<^sub>v = Suc t + n, coin\<^sub>v = chead\<rparr>) ` UNIV)
+    = infsum (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * real (Suc t + n) / (2::\<real>)) UNIV"
+    apply (subst infsum_reindex)
+    apply (simp add: inj_def)
+    by (simp add: infsum_cong)
+
+  have summable_f: "summable ?f"
+  proof -
+    have f1: "(\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * ((real t + real n))) = 
+          (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * (real t)  + ((1::\<real>) / (2::\<real>)) ^ n * (real n))"
+      by (metis (mono_tags, opaque_lifting) mult_of_nat_commute of_nat_add ring_class.ring_distribs(2))
+  
+    have f2: "(\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * real n) = (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * n)"
+      by simp
+    show "summable ?f"
+      apply (simp add: f1)
+       apply (subst summable_add)
+      apply (rule summable_mult2)
+      apply (rule summable_geometric)
+      apply simp
+      apply (subst summable_cong[where g = "(\<lambda>n::\<nat>. (n / (2::\<real>)^n))"])
+      apply (simp add: power_divide)
+      using summable_n_2_power_n apply blast
+      by simp
+  qed
+
+  have summable_f_1: "summable (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * ((1::\<real>) + (real t + real n)))"
+    proof -
+    have f1: "(\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * ((1::\<real>) + (real t + real n))) = 
+          (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * ((1::\<real>) + real t)  + ((1::\<real>) / (2::\<real>)) ^ n * (real n))"
+      by (metis (mono_tags, opaque_lifting) mult_of_nat_commute of_nat_Suc of_nat_add plus_nat.simps(2) ring_class.ring_distribs(2))
+
+    have f2: "(\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * real n) = (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * n)"
+      by simp
+    show "summable (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * ((1::\<real>) + (real t + real n)))"
+      apply (simp add: f1)
+      apply (subst summable_add)
+      apply (rule summable_mult2)
+      apply (rule summable_geometric)
+      apply simp
+      apply (subst summable_cong[where g = "(\<lambda>n::\<nat>. (n / (2::\<real>)^n))"])
+      apply (simp add: power_divide)
+      using summable_n_2_power_n apply blast
+      by simp
+  qed
+
+  have summable_f_suc_n: "summable (\<lambda>n. ?f (Suc n))"
+    apply (subst summable_Suc_iff)
+    using summable_f by auto
+  obtain l where P_l: "(\<lambda>n. ?f (Suc n)) sums l"
+    using summable_f_suc_n by blast
+
+  have sum_f0: "(\<lambda>n. ?f (Suc n)) sums l \<longleftrightarrow> ?f sums (l + ?f 0)"
+    apply (subst sums_Suc_iff)
+    by simp
+
+  have suminf_f_l: "?f sums (l + ?f 0)"
+    using P_l sum_f0 by blast
+
+  have suminf_f_l': "suminf ?f = l + real t"
+    using suminf_f_l sums_unique by force
+
+  have suminf_n_2_power_n: "(\<Sum>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * ((1::\<real>) + (real t + real n)) / (2::\<real>)) =  
+        (\<Sum>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n / 2 +  ((1::\<real>) / (2::\<real>)) ^ n * (real t + real n) / (2::\<real>))"
+    apply (rule suminf_cong)
+    by (simp add: ring_class.ring_distribs(1))
+  also have suminf_n_2_power_n': 
+    "... = (\<Sum>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n / 2) +  (\<Sum>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * (real t + real n) / (2::\<real>))"
+    apply (subst suminf_add)
+    using summable_2_power_n apply blast
+    apply (rule summable_comparison_test[where g = "(\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * ((1::\<real>) + (real t + real n)))"])
+    apply (auto)
+    using summable_f_1 by blast
+  also have suminf_n_2_power_n'': 
+    "... = (\<Sum>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n / 2) +  (\<Sum>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * (real t + real n)) / (2::\<real>)"
+    apply (subst suminf_divide[where f = "\<lambda>n. ((1::\<real>) / (2::\<real>)) ^ n * (real t + real n)"])
+    apply (rule summable_comparison_test[where g = "(\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * ((1::\<real>) + (real t + real n)))"])
+    apply (auto)
+    using summable_f_1 by blast
+  also have suminf_n_2_power_n''': "... = 1 + (\<Sum>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * (real t + real n)) / (2::\<real>)"
+    using power_half_series sums_unique by fastforce
+  also have suminf_n_2_power_n'''': "... = 1 + (l + real t) / 2"
+    using suminf_f_l' by presburger
+
+  have suminf_f_suc_n: "(\<Sum>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * ((1::\<real>) + (real t + real n)) / (2::\<real>)) = suminf (\<lambda>n. ?f (Suc n))"
+    by (metis (no_types, opaque_lifting) mult.commute mult_cancel_left2 nat_arith.suc1 of_nat_Suc of_nat_add power_Suc times_divide_eq_right)
+  have "l = 1 + (l + real t) / 2"
+    using P_l calculation suminf_f_l' suminf_f_suc_n sums_unique by auto
+  then have suminf_f_suc_n_l: "l = 2 + real t"
+    by (smt (z3) field_sum_of_halves)
+
+  have f0: "(\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state.
+          (if coin\<^sub>v v\<^sub>0 = chead then 1::\<real> else (0::\<real>)) * (if Suc t \<le> t\<^sub>v v\<^sub>0 then 1::\<real> else (0::\<real>)) *
+          ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v v\<^sub>0 - Suc t) * real (t\<^sub>v v\<^sub>0) / (2::\<real>)) = 
+        (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state.
+          (if coin\<^sub>v v\<^sub>0 = chead \<and> Suc t \<le> t\<^sub>v v\<^sub>0 then (((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v v\<^sub>0 - Suc t) *
+          real (t\<^sub>v v\<^sub>0) /  (2::\<real>)) else (0::\<real>)))"
+    apply (rule infsum_cong)
+    by (auto)
+  have f1: "... = (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state \<in> {v\<^sub>0. coin\<^sub>v v\<^sub>0 = chead \<and> Suc t \<le> t\<^sub>v v\<^sub>0}. 
+    (((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v v\<^sub>0 - Suc t) * real (t\<^sub>v v\<^sub>0) /  (2::\<real>)))"
+    apply (rule infsum_cong_neutral)
+    by (auto)
+  have f2: "... = infsum (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * real (Suc t + n) / (2::\<real>)) UNIV"
+    using reindex flip_t_set_eq''' by force
+  have f3: "... = (2::\<real>) + real t"
+    apply (subst infsetsum_infsum[symmetric])
+    apply (simp add: abs_summable_on_nat_iff')
+    using summable_f_1 apply blast
+    apply (subst infsetsum_nat)
+    apply (simp add: abs_summable_on_nat_iff')
+    using summable_f_1 apply blast
+    apply auto
+    using calculation suminf_f_l' suminf_f_suc_n_l by linarith
+    
+  show "(\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state.
+          (if coin\<^sub>v v\<^sub>0 = chead then 1::\<real> else (0::\<real>)) * (if Suc t \<le> t\<^sub>v v\<^sub>0 then 1::\<real> else (0::\<real>)) *
+          ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v v\<^sub>0 - Suc t) *
+          real (t\<^sub>v v\<^sub>0) / (2::\<real>)) = (2::\<real>) + real t "
+    using f0 f1 f2 f3 by presburger
+qed
+
 end

--- a/probability/probabilistic_relations/Examples/utp_prob_rel_lattice_coin.thy
+++ b/probability/probabilistic_relations/Examples/utp_prob_rel_lattice_coin.thy
@@ -1009,69 +1009,6 @@ lemma flip_t_loop: "flip_t_loop = prfun_of_rvfun Ht"
   using Ht_is_fp apply blast
   by simp
 
-lemma summable_n_2_power_n: 
-  "summable (\<lambda>n::\<nat>. (n / (2::\<real>)^n))" (is "summable ?f")
-  (* n:           0, 1,   2,   3,   4 *)
-  (*              0, 1/2, 2/4, 3/8, 4/16 *)
-  (* (n+1)/(2*n): x, 1,   3/4, 4/6, 5/8, ... *)
-  apply (subst summable_ratio_test[where c="3/4" and N="3"])
-  apply auto
-proof -
-  fix n::\<nat>
-  assume a1: "3 \<le> n"
-  have f1: "((1::\<real>) + real n) / ((2::\<real>) * (2::\<real>) ^ n) = ((n+1) / (2* n)) * (?f n)"
-    using a1 by auto
-  have f2: "((1::\<real>) + real n) / 1 \<le> (3::\<real>) * real n / ((2::\<real>))"
-    using a1 by force
-  have f3: "((1::\<real>) + real n) / ((2::\<real>) * (2::\<real>) ^ n) \<le> (3::\<real>) * real n / (2) / ((2::\<real>) * (2::\<real>) ^ n)"
-    apply (subst divide_right_mono[where c="((2::\<real>) * (2::\<real>) ^ n)"])
-    using f2 apply force
-    apply force
-    by simp
-  show "((1::\<real>) + real n) / ((2::\<real>) * (2::\<real>) ^ n) \<le> (3::\<real>) * real n / ((4::\<real>) * (2::\<real>) ^ n)"
-    apply (simp only: f1)
-    apply (auto)
-    using f3 by force
-qed
-
-lemma summable_2_power_n: "summable (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n / (2::\<real>))"
-  apply (rule summable_divide)
-  apply (rule summable_geometric)
-  by simp
-
-(*
-lemma summable_n_a_power_n: 
-  assumes "a \<ge> 2"
-  shows "summable (\<lambda>n::\<nat>. (n / (a::\<real>)^n))" (is "summable ?f")
-  (* n:           0, 1,   2,      3,    4 *)
-  (*              0, 1/a, 2/a^2, 3/a^3, 4/a^4 *)
-  (* (n+1)/(a*n): x, 2/a, 3/a*2, 4/a*3, 5/a*4, ... *)
-  apply (subst summable_ratio_test[where c="3/4" and N="3"])
-  apply auto
-proof -
-  fix n::\<nat>
-  assume a1: "3 \<le> n"
-  have f0: "\<bar>a * a ^ n\<bar> = a * a ^ n"
-    using assms by auto
-  have f1: "\<bar>a ^ n\<bar> = a ^ n"
-    using assms by auto
-  have f1: "((1::\<real>) + real n) / ((a::\<real>) * (a::\<real>) ^ n) = ((n+1) / (a* n)) * (?f n)"
-    using a1 by auto
-  have f2: "((1::\<real>) + real n) / 1 \<le> (3::\<real>) * real n / (4/a)"
-    apply auto
-  have f3: "((1::\<real>) + real n) / ((2::\<real>) * (2::\<real>) ^ n) \<le> (3::\<real>) * real n / (2) / ((2::\<real>) * (2::\<real>) ^ n)"
-    apply (subst divide_right_mono[where c="((2::\<real>) * (2::\<real>) ^ n)"])
-    using f2 apply force
-    apply force
-    by simp
-  show "((1::\<real>) + real n) / \<bar>a * a ^ n\<bar> \<le> (3::\<real>) * real n / ((4::\<real>) * \<bar>a ^ n\<bar>)"
-    apply (simp only: f0)
-    apply (simp only: f1)
-    apply (auto)
-    using f3 by force
-qed
-*)
-
 subsubsection \<open> Termination and average termination time \<close>
 lemma coin_flip_t_termination_prob: "Ht ; \<lbrakk>coin\<^sup>< = chead\<rbrakk>\<^sub>\<I>\<^sub>e = (1)\<^sub>e"
   apply (simp add: Ht_def)
@@ -1128,8 +1065,8 @@ next
     using calculation by presburger
 qed
 
-lemma coin_flip_t_expected_termination_time: "Ht ; (\<guillemotleft>real\<guillemotright> (t\<^sup><))\<^sub>e = 
-      (\<lbrakk>coin\<^sup>< = ctail\<rbrakk>\<^sub>\<I>\<^sub>e * (t\<^sup>< + 2)  + \<lbrakk>\<not>coin\<^sup>< = ctail\<rbrakk>\<^sub>\<I>\<^sub>e * t\<^sup>< )\<^sub>e"
+lemma coin_flip_t_expected_termination_time: 
+  "Ht ; (\<guillemotleft>real\<guillemotright> (t\<^sup><))\<^sub>e = (\<lbrakk>coin\<^sup>< = ctail\<rbrakk>\<^sub>\<I>\<^sub>e * (t\<^sup>< + 2)  + \<lbrakk>\<not>coin\<^sup>< = ctail\<rbrakk>\<^sub>\<I>\<^sub>e * t\<^sup>< )\<^sub>e"
   apply (pred_auto add: Ht_def)
 proof -
   fix t coint
@@ -1157,24 +1094,7 @@ next
     by (simp add: infsum_cong)
 
   have summable_f: "summable ?f"
-  proof -
-    have f1: "(\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * ((real t + real n))) = 
-          (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * (real t)  + ((1::\<real>) / (2::\<real>)) ^ n * (real n))"
-      by (metis (mono_tags, opaque_lifting) mult_of_nat_commute of_nat_add ring_class.ring_distribs(2))
-  
-    have f2: "(\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * real n) = (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * n)"
-      by simp
-    show "summable ?f"
-      apply (simp add: f1)
-       apply (subst summable_add)
-      apply (rule summable_mult2)
-      apply (rule summable_geometric)
-      apply simp
-      apply (subst summable_cong[where g = "(\<lambda>n::\<nat>. (n / (2::\<real>)^n))"])
-      apply (simp add: power_divide)
-      using summable_n_2_power_n apply blast
-      by simp
-  qed
+    using summable_1_2_power_n_t_n by blast
 
   have summable_f_1: "summable (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * ((1::\<real>) + (real t + real n)))"
     proof -

--- a/probability/probabilistic_relations/Examples/utp_prob_rel_lattice_dices.thy
+++ b/probability/probabilistic_relations/Examples/utp_prob_rel_lattice_dices.thy
@@ -2044,19 +2044,20 @@ proof -
           then show ?thesis
             using f21 f20 by linarith
         qed
-      have f3: "\<not>(fd2\<^sub>v x) = (fd2\<^sub>v y) \<Longrightarrow> \<not>(6::\<nat>) * (td2nat (fd1\<^sub>v x) - (1::\<nat>)) + td2nat (fd2\<^sub>v x) = 
-                  (6::\<nat>) * (td2nat (fd1\<^sub>v y) - (1::\<nat>)) + td2nat (fd2\<^sub>v y)"
-        proof (cases "(fd1\<^sub>v x) = (fd1\<^sub>v y)")
+      have f3: "\<not>(d2\<^sub>v x) = (d2\<^sub>v y) \<Longrightarrow> \<not>(6::\<nat>) * (td2nat (d1\<^sub>v x) - (1::\<nat>)) + td2nat (d2\<^sub>v x) = 
+                  (6::\<nat>) * (td2nat (d1\<^sub>v y) - (1::\<nat>)) + td2nat (d2\<^sub>v y)"
+        proof (cases "(d1\<^sub>v x) = (d1\<^sub>v y)")
           case True
           then show ?thesis 
-            using f1 td2nat_inject by force
+            using f1 td2nat_inject
+            by (smt (verit, best) a1 a2 add.commute diff_add_inverse2 mem_Collect_eq state_t_set_eq)
         next
           case False
           then show ?thesis 
             using f2 by blast
         qed
       show "False"
-        using f1 f2 f3 a3 by blast 
+        using f1 f2 f3 a3 by (smt (verit, best) a1 a2 mem_Collect_eq state_t_set_eq)
     qed
 
   have inj_set: "?f ` (state_t_set t\<^sub>0) = {(1::\<nat>)..36}"
@@ -2082,8 +2083,8 @@ definition dice_throw_loop where
 "dice_throw_loop = while\<^sub>p\<^sub>t (d1\<^sup>< \<noteq> d2\<^sup><)\<^sub>e do dice_throw od"
 
 definition Ht:: "state_t rvhfun" where 
-"Ht = ((\<lbrakk>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>d1\<^sup>> = d1\<^sup>< \<and> d2\<^sup>> = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e) + 
-  \<lbrakk>\<not>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>d1\<^sup>> = d2\<^sup>>\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk> $t\<^sup>> \<ge> $t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e  * (1/6)^(($t\<^sup>> - $t\<^sup>< - 1)) * (5/6))\<^sub>e"
+"Ht = ((\<lbrakk>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>t\<^sup>> = t\<^sup>< \<and> d1\<^sup>> = d1\<^sup>< \<and> d2\<^sup>> = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e) + 
+      \<lbrakk>\<not>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>d1\<^sup>> = d2\<^sup>>\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk> $t\<^sup>> \<ge> $t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e  * (5/6)^($t\<^sup>> - $t\<^sup>< - 1) * (1/6))\<^sub>e"
 
 subsubsection \<open> Theorems \<close>
 lemma d1_uni_is_dist: 
@@ -2278,12 +2279,23 @@ qed
 definition dice_throw_t_alt :: "state_t rvhfun" where
 "dice_throw_t_alt \<equiv> (\<lbrakk>d1\<^sup>> \<in> outcomes1\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>d2\<^sup>> \<in> outcomes1\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>t\<^sup>> = t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e / 36)\<^sub>e"
 
+lemma dice_throw_t_alt_eq: "dice_throw_t_alt = (\<lbrakk>t\<^sup>> = t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e / 36)\<^sub>e"
+  apply (simp add: dice_throw_t_alt_def)
+  apply (pred_auto)
+  using Tdice_mem apply auto[1]
+  using Tdice_mem apply auto[1]
+  using Tdice_mem apply auto[1]
+  using Tdice_mem apply auto[1]
+  using Tdice_mem apply auto[1]
+  using Tdice_mem apply auto[1]
+  using Tdice_mem by auto[1]
+
 lemma state_t_add_1: "(rvfun_of_prfun ((t := $t + 1)::state_t prhfun)) = 
   (\<lbrakk>d1\<^sup>> = d1\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>d2\<^sup>> = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>t\<^sup>> = t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e)\<^sub>e"
   apply (simp add: pfun_defs rvfun_assignment_inverse)
   by (pred_auto)
 
-lemma state_t_set_eq_1: "{s::state_t. t\<^sub>v s = a \<and> b = d1\<^sub>v s \<and> c = d2\<^sub>v s} = {\<lparr>t\<^sub>v = a, d1\<^sub>v = b, d2\<^sub>v = c\<rparr>}"
+lemma state_t_set_eq_1: "{s::state_t. t\<^sub>v s = a \<and> d1\<^sub>v s = b \<and> d2\<^sub>v s = c} = {\<lparr>t\<^sub>v = a, d1\<^sub>v = b, d2\<^sub>v = c\<rparr>}"
   apply (simp add: set_eq_iff)
   by auto
 
@@ -2309,7 +2321,10 @@ proof -
   also have "... = 1/36"
     apply (subst infsum_constant_finite_states)
     apply (simp add: state_t_finite)
-    by (simp add: state_t_set_eq_1)
+    apply (subgoal_tac "{s::state_t. t\<^sub>v s = t\<^sub>v a \<and> d1\<^sub>v b = d1\<^sub>v s \<and> d2\<^sub>v b = d2\<^sub>v s} = 
+                        {s::state_t. t\<^sub>v s = t\<^sub>v a \<and> d1\<^sub>v s = d1\<^sub>v b \<and> d2\<^sub>v s = d2\<^sub>v b}")
+    apply (simp add: state_t_set_eq_1)
+    by auto
   then show "?lhs * 36 = 1"
     by (simp add: calculation)
 next
@@ -2332,46 +2347,44 @@ lemma dice_throw_t_is_dist: "is_final_distribution dice_throw_t_alt"
   apply (subst infsum_constant_finite_states)
   using state_t_finite apply blast
   by (metis card_state_t_set lambda_one of_nat_numeral state_t_set_eq)
-(*
-lemma H_is_dist: "is_final_distribution Ht"
-  apply (simp add: dist_defs H_def)
-  apply (simp add: expr_defs)
-  apply (auto)
-  apply (smt (verit, best) field_sum_of_halves power_le_one)
-  apply (simp add: lens_defs)
-proof -
-  fix s\<^sub>1::"coin_t_state"
-  let ?lhs = "(\<Sum>\<^sub>\<infinity>s::coin_t_state.
-          (if coin\<^sub>v s = chead \<and> Suc (t\<^sub>v s\<^sub>1) \<le> t\<^sub>v s then 1::\<real> else (0::\<real>)) *
-          ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v s - Suc (t\<^sub>v s\<^sub>1)) / (2::\<real>))"
-  let ?set = "{s::coin_t_state. coin\<^sub>v s = chead \<and> Suc (t\<^sub>v s\<^sub>1) \<le> t\<^sub>v s}"
 
-  (*
-  thm "infsum_reindex"
-  have "(\<Sum>\<^sub>\<infinity>t::nat \<in> {t. t \<ge> Suc (t\<^sub>v s\<^sub>1)}. ((1::\<real>) / (2::\<real>)) ^ (t - Suc (t\<^sub>v s\<^sub>1) + 1)) = 1"
-    apply (subst infsum_reindex[where h = "\<lambda>s::coin_t_state. t\<^sub>v s" and A = "?set"])
-*)
-  have f1: "?lhs = (\<Sum>\<^sub>\<infinity>s::coin_t_state \<in> ?set \<union> -?set.
-          (if coin\<^sub>v s = chead \<and> Suc (t\<^sub>v s\<^sub>1) \<le> t\<^sub>v s then 1::\<real> else (0::\<real>)) *
-          ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v s - Suc (t\<^sub>v s\<^sub>1)) / (2::\<real>))"
-    by auto
-  moreover have "... = (\<Sum>\<^sub>\<infinity>s::coin_t_state \<in> ?set.
-          (if coin\<^sub>v s = chead \<and> Suc (t\<^sub>v s\<^sub>1) \<le> t\<^sub>v s then 1::\<real> else (0::\<real>)) *
-          ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v s - Suc (t\<^sub>v s\<^sub>1)) / (2::\<real>))"
+(*
+lemma Ht_is_dist: "is_final_distribution Ht"
+  apply (simp add: dist_defs Ht_def)
+  apply (simp add: expr_defs)
+  apply (pred_auto)
+  apply (subst infsum_constant_finite_states)
+  apply (simp add: state_t_finite)
+  apply (subst state_t_set_eq_1)
+  apply (simp)
+  apply (subgoal_tac "((5::\<real>) / (6::\<real>)) ^ (t\<^sub>v' - Suc t)  \<le> 1")
+  apply linarith
+  apply (simp add: power_le_one_iff)
+proof -
+  fix t::\<nat> and d1::Tdice and d2::Tdice
+  let ?lhs = "(\<Sum>\<^sub>\<infinity>s::state_t. (if d1\<^sub>v s = d2\<^sub>v s then 1::\<real> else (0::\<real>)) * 
+          (if Suc t \<le> t\<^sub>v s then 1::\<real> else (0::\<real>)) *
+          ((5::\<real>) / (6::\<real>)) ^ (t\<^sub>v s - Suc t) / (6::\<real>))"
+  let ?set = "{s::state_t. d1\<^sub>v s = d2\<^sub>v s \<and> Suc t \<le> t\<^sub>v s}"
+
+  have f1: "?lhs = (\<Sum>\<^sub>\<infinity>s::state_t \<in> ?set \<union> -?set.
+    (if d1\<^sub>v s = d2\<^sub>v s \<and> Suc t \<le> t\<^sub>v s then (((5::\<real>) / (6::\<real>)) ^ (t\<^sub>v s - Suc t) / (6::\<real>)) else (0::\<real>)))"
+    by (smt (verit, best) boolean_algebra.disj_cancel_right div_0 infsum_cong mult_cancel_right2 mult_eq_0_iff)
+  moreover have "... = (\<Sum>\<^sub>\<infinity>s::state_t \<in> ?set. (if d1\<^sub>v s = d2\<^sub>v s \<and> Suc t \<le> t\<^sub>v s then 
+            (((5::\<real>) / (6::\<real>)) ^ (t\<^sub>v s - Suc t) / (6::\<real>)) else (0::\<real>)))"
     apply (rule infsum_cong_neutral)
     apply force
     apply simp
     by blast
-  moreover have "... = (\<Sum>\<^sub>\<infinity>s::coin_t_state \<in> ?set. ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v s - Suc (t\<^sub>v s\<^sub>1)) / (2::\<real>))"
+  moreover have "... = (\<Sum>\<^sub>\<infinity>s::state_t \<in> ?set. (((5::\<real>) / (6::\<real>)) ^ (t\<^sub>v s - Suc t) / (6::\<real>)))"
     by (smt (verit) infsum_cong mem_Collect_eq mult_cancel_right2)
-  moreover have "... = (\<Sum>\<^sub>\<infinity>s::coin_t_state \<in> ?set. ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v s - Suc (t\<^sub>v s\<^sub>1) + 1))"
-    by auto
-  moreover have "... = (\<Sum>\<^sub>\<infinity>t::nat \<in> {t. t \<ge> Suc (t\<^sub>v s\<^sub>1)}. ((1::\<real>) / (2::\<real>)) ^ (t - Suc (t\<^sub>v s\<^sub>1) + 1))"
-    apply (subst infsum_reindex_bij_betw[symmetric, where g = "\<lambda>s::coin_t_state. t\<^sub>v s" and A = "?set"])
+  moreover have "... = (\<Sum>\<^sub>\<infinity>tt::nat \<in> {tt. tt \<ge> Suc t}. (((5::\<real>) / (6::\<real>)) ^ (tt - Suc t) / (6::\<real>)))"
+    apply (subst infsum_reindex_bij_betw[symmetric, where g = "\<lambda>s::state_t. t\<^sub>v s" and A = "?set"])
     apply (simp add: bij_betw_def)
     apply (rule conjI)
     apply (simp add: inj_on_def)
     apply auto
+    sledgehammer
     apply (simp add: image_def)
     apply (rule_tac x = "\<lparr>t\<^sub>v = x, coin\<^sub>v = chead\<rparr>" in exI)
     by simp
@@ -2401,83 +2414,91 @@ proof -
 qed
 *)
 
+(*
+((\<lbrakk>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>t\<^sup>> = t\<^sup>< \<and> d1\<^sup>> = d1\<^sup>< \<and> d2\<^sup>> = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e) + 
+      \<lbrakk>\<not>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>d1\<^sup>> = d2\<^sup>>\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk> $t\<^sup>> \<ge> $t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e  * (5/6)^($t\<^sup>> - $t\<^sup>< - 1) * (1/6))\<^sub>e"
+
+if (d1\<^sup>< \<noteq> d2\<^sup><)\<^sub>e then ((Pt dice_throw) ; Ht) else II = Ht
+  \<lbrakk>\<not>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e* ((\<lbrakk>t\<^sup>> = t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e / 36)\<^sub>e ; Ht) 
+= \<lbrakk>\<not>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e* (\<Sum>\<^sub>\<infinity>v\<^sub>0::state_t. \<lbrakk>t\<^sub>v v\<^sub>0 = t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e / 36 * (
+    (\<lbrakk>d1\<^sub>v v\<^sub>0 = d2\<^sub>v v\<^sub>0\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>t\<^sup>> = t\<^sub>v v\<^sub>0 \<and> d1\<^sup>> = d1\<^sub>v v\<^sub>0 \<and> d2\<^sup>> = d2\<^sub>v v\<^sub>0\<rbrakk>\<^sub>\<I>\<^sub>e) +
+    \<lbrakk>\<not>d1\<^sub>v v\<^sub>0 = d2\<^sub>v v\<^sub>0\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>d1\<^sup>> = d2\<^sup>>\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk> t\<^sup>> \<ge> t\<^sub>v v\<^sub>0 + 1\<rbrakk>\<^sub>\<I>\<^sub>e  * (5/6)^(t\<^sup>> - t\<^sub>v v\<^sub>0 - 1) * (1/6)
+  )
+= \<lbrakk>\<not>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e* (\<Sum>\<^sub>\<infinity>v\<^sub>0::state_t. \<lbrakk>t\<^sub>v v\<^sub>0 = t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e *\<lbrakk>d1\<^sub>v v\<^sub>0 = d2\<^sub>v v\<^sub>0\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>t\<^sup>> = t\<^sub>v v\<^sub>0 \<and> d1\<^sup>> = d1\<^sub>v v\<^sub>0 \<and> d2\<^sup>> = d2\<^sub>v v\<^sub>0\<rbrakk>\<^sub>\<I>\<^sub>e)/36 +
+  \<lbrakk>\<not>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e* (\<Sum>\<^sub>\<infinity>v\<^sub>0::state_t. \<lbrakk>t\<^sub>v v\<^sub>0 = t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e *\<lbrakk>\<not>d1\<^sub>v v\<^sub>0 = d2\<^sub>v v\<^sub>0\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>d1\<^sup>> = d2\<^sup>>\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk> t\<^sup>> \<ge> t\<^sub>v v\<^sub>0 + 1\<rbrakk>\<^sub>\<I>\<^sub>e  * (5/6)^(t\<^sup>> - t\<^sub>v v\<^sub>0 - 1) * (1/6) /36)
+= \<lbrakk>\<not>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>d1\<^sup>> = d2\<^sup>>\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>t\<^sup>> = t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e / 6 +
+  \<lbrakk>\<not>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>d1\<^sup>> = d2\<^sup>>\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk> t\<^sup>> \<ge> t\<^sup>< + 2\<rbrakk>\<^sub>\<I>\<^sub>e  * (5/6)^(t\<^sup>> - t\<^sup>< - 1) * (1/6))
+= \<lbrakk>\<not>d1\<^sup>< = d2\<^sup><\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk>d1\<^sup>> = d2\<^sup>>\<rbrakk>\<^sub>\<I>\<^sub>e * \<lbrakk> $t\<^sup>> \<ge> $t\<^sup>< + 1\<rbrakk>\<^sub>\<I>\<^sub>e  * (5/6)^($t\<^sup>> - $t\<^sup>< - 1) * (1/6)
+*)
+
 lemma Ht_is_fp: "\<F> (d1\<^sup>< \<noteq> d2\<^sup><)\<^sub>e (Pt dice_throw) (prfun_of_rvfun (Ht)) = prfun_of_rvfun (Ht)"
   apply (simp add: Ht_def loopfunc_def)
-  apply (simp add: pfun_defs flip_t)
-  apply (subst flip_t_alt_def)
+  apply (simp add: pfun_defs dice_throw_t)
+  (* apply (subst dice_throw_t_alt_def) *)
   apply (subst rvfun_skip_inverse)
   apply (subst rvfun_skip\<^sub>_f_simp)
   apply (subst rvfun_seqcomp_inverse)
-  using flip_t_alt_def flip_t_is_dist rvfun_inverse rvfun_prob_sum1_summable'(1) apply force
+  apply (simp add: dice_throw_t_is_dist rvfun_inverse rvfun_prob_sum1_summable'(1))
   using ureal_is_prob apply blast
   apply (subst rvfun_inverse)
-  apply (expr_auto add: dist_defs)
+   apply (simp add: dice_throw_t_is_dist rvfun_prob_sum1_summable'(1))
   apply (subst rvfun_inverse)
   apply (expr_auto add: dist_defs)
-  apply (smt (verit, del_insts) One_nat_def add.commute plus_1_eq_Suc power_0 power_le_one_iff power_one_over power_one_right sum_1_2 sum_geometric_series')
-  apply (expr_auto add: prfun_of_rvfun_def skip_def)
-  using Tcoin.exhaust apply blast
-  using Tcoin.exhaust apply blast
+  apply (subgoal_tac "((5::\<real>) / (6::\<real>)) ^ (t\<^sub>v' - Suc t)  \<le> 1")
+  apply linarith
+  apply (simp add: power_le_one_iff)
+  apply (simp only: dice_throw_t_alt_def)
+  apply (rule HOL.arg_cong[where f="prfun_of_rvfun"])
+  apply (pred_auto)
+  apply (simp only: d1_if_simp d2_if_simp)
+  defer
+  apply (smt (verit, best) divide_eq_0_iff infsum_0 mult_not_zero)
+  apply (smt (verit, best) Suc_leD divide_eq_0_iff infsum_0 mult_eq_0_iff not_less_eq_eq)
+  apply (simp add: infsum_0)
+  apply (auto)
 proof -
-  fix t t\<^sub>v'
+  fix d1::Tdice and d2::Tdice and t::\<nat> and t\<^sub>v'::\<nat> and d2\<^sub>v'::Tdice
+  assume a0: "\<not> d1 = d2"
   assume a1: "Suc t \<le> t\<^sub>v'"
-  let ?f1 = "\<lambda>v\<^sub>0::coin_t_state. (if (coin\<^sub>v v\<^sub>0 = chead \<or> coin\<^sub>v v\<^sub>0 = ctail) \<and> t\<^sub>v v\<^sub>0 = Suc t then 1::\<real> else (0::\<real>))"
-  let ?f2 = "\<lambda>v\<^sub>0::coin_t_state. ((if coin\<^sub>v v\<^sub>0 = ctail then 1::\<real> else (0::\<real>)) * (if Suc (t\<^sub>v v\<^sub>0) \<le> t\<^sub>v' then 1::\<real> else (0::\<real>)) *
-            ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v' - Suc (t\<^sub>v v\<^sub>0)) / (2::\<real>) +
-            (if \<not> coin\<^sub>v v\<^sub>0 = ctail then 1::\<real> else (0::\<real>)) * (if t\<^sub>v' = t\<^sub>v v\<^sub>0 then 1::\<real> else (0::\<real>)))"
-  have set_eq_1: "{s::coin_t_state. coin\<^sub>v s = ctail \<and> t\<^sub>v s = Suc t \<and> Suc (t\<^sub>v s) \<le> t\<^sub>v'} = 
-        (if Suc (Suc t) \<le> t\<^sub>v' then {\<lparr>t\<^sub>v = Suc t, coin\<^sub>v = ctail\<rparr>} else {})"
-    by auto
-
-  have set_eq_2: "{s::coin_t_state. coin\<^sub>v s = chead \<and> t\<^sub>v' = t\<^sub>v s \<and> t\<^sub>v s = Suc t} = 
-        (if (Suc t) = t\<^sub>v' then {\<lparr>t\<^sub>v = Suc t, coin\<^sub>v = chead\<rparr>} else {})"
-    apply (simp)
-    apply (rule impI)
-    apply (subst set_eq_iff)
-    by (smt (verit, best) coin_t_state.equality coin_t_state.select_convs(1) mem_Collect_eq old.unit.exhaust singleton_iff time.select_convs(1))
-  
-  have "(\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. ?f1 v\<^sub>0 * ?f2 v\<^sub>0 / (2::\<real>)) =
-        (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. (if coin\<^sub>v v\<^sub>0 = ctail \<and> t\<^sub>v v\<^sub>0 = Suc t \<and> Suc (t\<^sub>v v\<^sub>0) \<le> t\<^sub>v' then 1 else 0) * 
-            ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v' - Suc (t\<^sub>v v\<^sub>0)) / (2::\<real>) / 2  + 
-           (if coin\<^sub>v v\<^sub>0 = chead \<and> t\<^sub>v'  = t\<^sub>v v\<^sub>0 \<and> t\<^sub>v v\<^sub>0 = Suc t then 1 else 0) / 2)"
-    apply (rule infsum_cong)
-    by (auto)
-  also have "... = (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. (if coin\<^sub>v v\<^sub>0 = ctail \<and> t\<^sub>v v\<^sub>0 = Suc t \<and> Suc (t\<^sub>v v\<^sub>0) \<le> t\<^sub>v' then 
-                (((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v' - Suc (Suc t)) / (2::\<real>) / 2) else 0) + 
-           (if coin\<^sub>v v\<^sub>0 = chead \<and> t\<^sub>v'  = t\<^sub>v v\<^sub>0 \<and> t\<^sub>v v\<^sub>0 = Suc t then 1/2 else 0))"
-    apply (rule infsum_cong)
-    by (auto)
-  also have "... = (((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v' - Suc t) / (2::\<real>))"
+  let ?lhs = "(\<Sum>\<^sub>\<infinity>v\<^sub>0::state_t.
+          (if t\<^sub>v v\<^sub>0 = Suc t then 1::\<real> else (0::\<real>)) *
+          ((if d1\<^sub>v v\<^sub>0 = d2\<^sub>v v\<^sub>0 then 1::\<real> else (0::\<real>)) * (if t\<^sub>v' = t\<^sub>v v\<^sub>0 \<and> d2\<^sub>v' = d1\<^sub>v v\<^sub>0 \<and> d2\<^sub>v' = d2\<^sub>v v\<^sub>0 then 1::\<real> else (0::\<real>)) +
+           (if \<not> d1\<^sub>v v\<^sub>0 = d2\<^sub>v v\<^sub>0 then 1::\<real> else (0::\<real>)) * (if Suc (t\<^sub>v v\<^sub>0) \<le> t\<^sub>v' then 1::\<real> else (0::\<real>)) *
+           ((5::\<real>) / (6::\<real>)) ^ (t\<^sub>v' - Suc (t\<^sub>v v\<^sub>0)) / (6::\<real>)) / (36::\<real>))"
+  have f0: "?lhs = (\<Sum>\<^sub>\<infinity>v\<^sub>0::state_t.
+          ((if t\<^sub>v v\<^sub>0 = Suc t \<and> t\<^sub>v' = t\<^sub>v v\<^sub>0 \<and> d2\<^sub>v' = d1\<^sub>v v\<^sub>0 \<and> d2\<^sub>v' = d2\<^sub>v v\<^sub>0 then 1/36 else (0::\<real>)) +
+           (if t\<^sub>v v\<^sub>0 = Suc t \<and> \<not> d1\<^sub>v v\<^sub>0 = d2\<^sub>v v\<^sub>0 \<and> Suc (Suc t) \<le> t\<^sub>v' then ((5::\<real>) / (6::\<real>)) ^ (t\<^sub>v' - Suc (Suc t)) /
+           (6::\<real>) / 36 else (0::\<real>))))"
+    by (smt (verit, best) divide_eq_0_iff infsum_cong mult_cancel_right1 mult_not_zero)
+  moreover have f1: "... = (if Suc t = t\<^sub>v' then 1/36 else ((5::\<real>) / (6::\<real>)) ^ (t\<^sub>v' - Suc (Suc t)) / (6::\<real>) / 36)"
     apply (subst infsum_add)
-    apply (rule infsum_constant_finite_states_summable)
-    apply (simp add: set_eq_1)
-    apply (rule infsum_constant_finite_states_summable)
-    apply (smt (verit, best) finite.emptyI finite.intros(2) flip_t_set_eq mem_Collect_eq rev_finite_subset subset_eq)
-    apply (subst infsum_constant_finite_states)
-    apply (simp add: set_eq_1)
-    apply (subst infsum_constant_finite_states)
-    apply (simp add: set_eq_2)
-    apply (simp add: set_eq_1 set_eq_2)
-    by (smt (verit, ccfv_threshold) Suc_diff_le a1 add.commute diff_Suc_Suc divide_divide_eq_left le_antisym not_less_eq_eq plus_1_eq_Suc power_Suc2 power_one_over sum_1_2 sum_geometric_series')
-  then show "real2ureal
-        (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state. ?f1 v\<^sub>0 * ?f2 v\<^sub>0 / (2::\<real>)) =
-       real2ureal (((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v' - Suc t) / (2::\<real>))"
-    using calculation by presburger    
-next
-  fix t t\<^sub>v'
-  assume a1: "\<not> Suc t \<le> t\<^sub>v'"
-
-  show "real2ureal
-        (\<Sum>\<^sub>\<infinity>v\<^sub>0::coin_t_state.
-           (if (coin\<^sub>v v\<^sub>0 = chead \<or> coin\<^sub>v v\<^sub>0 = ctail) \<and> t\<^sub>v v\<^sub>0 = Suc t then 1::\<real> else (0::\<real>)) *
-           ((if coin\<^sub>v v\<^sub>0 = ctail then 1::\<real> else (0::\<real>)) * (if Suc (t\<^sub>v v\<^sub>0) \<le> t\<^sub>v' then 1::\<real> else (0::\<real>)) *
-            ((1::\<real>) / (2::\<real>)) ^ (t\<^sub>v' - Suc (t\<^sub>v v\<^sub>0)) /
-            (2::\<real>) +
-            (if \<not> coin\<^sub>v v\<^sub>0 = ctail then 1::\<real> else (0::\<real>)) * (if t\<^sub>v' = t\<^sub>v v\<^sub>0 then 1::\<real> else (0::\<real>))) /
-           (2::\<real>)) = real2ureal (0::\<real>)"
-    apply (subst infsum_0)
-    using a1 apply force
-    by simp
+    apply (simp add: infsum_constant_finite_states_summable state_t_finite)
+    apply (simp add: infsum_constant_finite_states_summable state_t_finite)
+    apply (subst infsum_constant_finite_states_subset)
+    apply (simp add: infsum_constant_finite_states_summable state_t_finite)
+    apply (subst infsum_constant_finite_states_subset)
+    apply (simp add: infsum_constant_finite_states_summable state_t_finite)
+    apply (auto)
+  proof -
+    assume a: "t\<^sub>v' = Suc t"
+    have f0: "{s::state_t. t\<^sub>v s = Suc t \<and> Suc t = t\<^sub>v s \<and> d2\<^sub>v' = d1\<^sub>v s \<and> d2\<^sub>v' = d2\<^sub>v s} = 
+          {s::state_t. t\<^sub>v s = Suc t \<and> d2\<^sub>v' = d1\<^sub>v s \<and> d2\<^sub>v' = d2\<^sub>v s}"
+      by fastforce
+    show "card {s::state_t. t\<^sub>v s = Suc t \<and> Suc t = t\<^sub>v s \<and> d2\<^sub>v' = d1\<^sub>v s \<and> d2\<^sub>v' = d2\<^sub>v s} = Suc (0::\<nat>)"
+      apply (simp add: f0)
+      by (smt (verit, ccfv_threshold) card_1_singleton old.unit.exhaust state_t.select_convs(1) 
+          state_t.select_convs(2) state_t.surjective time.select_convs(1))
+  next
+    assume a: "\<not> Suc t = t\<^sub>v'"
+    show "(6::\<real>) * real (card {s::state_t. t\<^sub>v s = Suc t \<and> t\<^sub>v' = t\<^sub>v s \<and> d2\<^sub>v' = d1\<^sub>v s \<and> d2\<^sub>v' = d2\<^sub>v s}) +
+    ((5::\<real>) / (6::\<real>)) ^ (t\<^sub>v' - Suc (Suc t)) * real (card {s::state_t. t\<^sub>v s = Suc t \<and> \<not> d1\<^sub>v s = d2\<^sub>v s \<and> Suc (Suc t) \<le> t\<^sub>v'}) =
+    ((5::\<real>) / (6::\<real>)) ^ (t\<^sub>v' - Suc (Suc t))"
+      sorry
+  qed
+  show "?lhs * (6::\<real>) =  ((5::\<real>) / (6::\<real>)) ^ (t\<^sub>v' - Suc t)"
+    apply (simp only: f0 f1)
+    apply (auto)
+  qed
 qed
 
 lemma Pt_flip_finite: "\<forall>s. finite {s'::coin_t_state. (0::ureal) < Pt flip_t (s, s')}"

--- a/probability/probabilistic_relations/Examples/utp_prob_rel_lattice_symmetric_random_walker.thy
+++ b/probability/probabilistic_relations/Examples/utp_prob_rel_lattice_symmetric_random_walker.thy
@@ -9,14 +9,14 @@ unbundle UTP_Syntax
 
 declare [[show_types]]
 
-alphabet srwstate = 
+alphabet srwstate = time + 
   x :: nat
 
-definition f:: "srwstate prhfun" where
-"f = if\<^sub>p 0.5 then (x := x - 1) else (x := x + 1)"
+definition move:: "srwstate prhfun" where
+"move = if\<^sub>p 0.5 then (x := x - 1) else (x := x + 1)"
 
 definition sym_random_walker where
-"sym_random_walker = while\<^sub>p (x\<^sup>< > 0)\<^sub>e do f od"
+"sym_random_walker = while\<^sub>p\<^sub>t (x\<^sup>< > 0)\<^sub>e do move od"
 
 lemma cflip_iter_seq_tendsto_0:
   "\<forall>s::srwstate \<times> srwstate. (\<lambda>n::\<nat>. ureal2real (iter_seq n (x\<^sup>< > 0)\<^sub>e f 1\<^sub>p s)) \<longlonglongrightarrow> (0::\<real>)"

--- a/probability/probabilistic_relations/README.md
+++ b/probability/probabilistic_relations/README.md
@@ -1,8 +1,17 @@
+- [Mechanisation of probabilistic designs in Isabelle/UTP](#mechanisation-of-probabilistic-designs-in-isabelleutp)
+- [Installation/Set up instructions](#installationset-up-instructions)
+  - [Clone this repository](#clone-this-repository)
+  - [Isabelle/UTP distributions with prebuild heap images on Linux](#isabelleutp-distributions-with-prebuild-heap-images-on-linux)
+  - [Standard](#standard)
+
 # Mechanisation of probabilistic designs in Isabelle/UTP
 This folder (`probabilistic_relations`) contains our mechanisation of the theory of probabilistic relations in [Isabelle/UTP](https://isabelle-utp.york.ac.uk/), a UTP proof framework in Isabelle/HOL.
 
 # Installation/Set up instructions
 This instruction is based on Ubuntu/Linux. It would be similar on other operation systems.
+The first step is to [Clone this repository](#clone-this-repository), and then you can use 
+- [Isabelle/UTP distributions with prebuild heap images on Linux](#isabelleutp-distributions-with-prebuild-heap-images-on-linux) or 
+- [Standard](#standard) procedure to install Isabelle/HOL.
 
 ## Clone this repository
 1. Clone and enter the folder of this probabilistic relations

--- a/probability/probabilistic_relations/infsum_laws.thy
+++ b/probability/probabilistic_relations/infsum_laws.thy
@@ -291,6 +291,25 @@ proof -
     using a1 by presburger
 qed
 
+lemma infsum_constant_finite_states_subset:
+  assumes "finite {s. b s \<and> s \<in> A}"
+  shows "(\<Sum>\<^sub>\<infinity>v\<^sub>0::'a \<in> A. (if b v\<^sub>0 then (m::\<real>) else 0)) = m * card ({s. b s \<and> s \<in> A})"
+proof -
+  have "(\<Sum>\<^sub>\<infinity>v\<^sub>0::'a \<in> A. (if b v\<^sub>0 then (m::\<real>) else 0)) = (\<Sum>\<^sub>\<infinity>v\<^sub>0::'a \<in> {s. b s \<and> s \<in> A}. (m::\<real>))"
+    apply (rule infsum_cong_neutral)
+    apply simp
+    apply auto[1]
+    by simp
+  then show ?thesis
+    by simp
+qed
+
+lemma infsum_constant_finite_states_subset':
+  assumes "finite {s. b s}"
+  shows "(\<Sum>\<^sub>\<infinity>v\<^sub>0::'a \<in> A. (if b v\<^sub>0 then (m::\<real>) else 0)) = m * card ({s. b s \<and> s \<in> A})"
+  apply (rule infsum_constant_finite_states_subset)
+  using assms by force
+
 lemma infsum_constant_finite_states_summable_2:
   assumes "finite {s. b\<^sub>1 s}" "finite {s. b\<^sub>2 s}"
   shows "(\<lambda>v\<^sub>0::'a. (if b\<^sub>1 v\<^sub>0 then (m::\<real>) else 0) + 
@@ -572,4 +591,9 @@ proof -
     using f1 nless_le by blast
 qed
 
+subsection \<open> Series \<close>
+
+(*
+lemma "sum "
+*)
 end

--- a/probability/probabilistic_relations/infsum_laws.thy
+++ b/probability/probabilistic_relations/infsum_laws.thy
@@ -595,9 +595,10 @@ subsection \<open> Series \<close>
 
 lemma summable_n_2_power_n: 
   "summable (\<lambda>n::\<nat>. (n / (2::\<real>)^n))" (is "summable ?f")
-  (* n:           0, 1,   2,   3,   4 *)
-  (*              0, 1/2, 2/4, 3/8, 4/16 *)
-  (* (n+1)/(2*n): x, 1,   3/4, 4/6, 5/8, ... *)
+  (* n:                   0, 1,   2,   3,   4 *)
+  (* n/2^n                0, 1/2, 2/4, 3/8, 4/16 *)
+  (* (n+1)/(2^(n+1)):   1/2, 2/4, 3/8, 4/6, 5/8, ... *)
+  (* ratio ((n+1)/2*n):   x, 1,   3/4, 4/6, 5/8, ... *)
   apply (subst summable_ratio_test[where c="3/4" and N="3"])
   apply auto
 proof -

--- a/probability/probabilistic_relations/infsum_laws.thy
+++ b/probability/probabilistic_relations/infsum_laws.thy
@@ -593,7 +593,88 @@ qed
 
 subsection \<open> Series \<close>
 
+lemma summable_n_2_power_n: 
+  "summable (\<lambda>n::\<nat>. (n / (2::\<real>)^n))" (is "summable ?f")
+  (* n:           0, 1,   2,   3,   4 *)
+  (*              0, 1/2, 2/4, 3/8, 4/16 *)
+  (* (n+1)/(2*n): x, 1,   3/4, 4/6, 5/8, ... *)
+  apply (subst summable_ratio_test[where c="3/4" and N="3"])
+  apply auto
+proof -
+  fix n::\<nat>
+  assume a1: "3 \<le> n"
+  have f1: "((1::\<real>) + real n) / ((2::\<real>) * (2::\<real>) ^ n) = ((n+1) / (2* n)) * (?f n)"
+    using a1 by auto
+  have f2: "((1::\<real>) + real n) / 1 \<le> (3::\<real>) * real n / ((2::\<real>))"
+    using a1 by force
+  have f3: "((1::\<real>) + real n) / ((2::\<real>) * (2::\<real>) ^ n) \<le> (3::\<real>) * real n / (2) / ((2::\<real>) * (2::\<real>) ^ n)"
+    apply (subst divide_right_mono[where c="((2::\<real>) * (2::\<real>) ^ n)"])
+    using f2 apply force
+    apply force
+    by simp
+  show "((1::\<real>) + real n) / ((2::\<real>) * (2::\<real>) ^ n) \<le> (3::\<real>) * real n / ((4::\<real>) * (2::\<real>) ^ n)"
+    apply (simp only: f1)
+    apply (auto)
+    using f3 by force
+qed
+
+lemma summable_2_power_n: "summable (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n / (2::\<real>))"
+  apply (rule summable_divide)
+  apply (rule summable_geometric)
+  by simp
+
 (*
-lemma "sum "
+lemma summable_n_a_power_n: 
+  assumes "a \<ge> 2"
+  shows "summable (\<lambda>n::\<nat>. (n / (a::\<real>)^n))" (is "summable ?f")
+  (* n:           0, 1,   2,      3,    4 *)
+  (*              0, 1/a, 2/a^2, 3/a^3, 4/a^4 *)
+  (* (n+1)/(a*n): x, 2/a, 3/a*2, 4/a*3, 5/a*4, ... *)
+  apply (subst summable_ratio_test[where c="3/4" and N="3"])
+  apply auto
+proof -
+  fix n::\<nat>
+  assume a1: "3 \<le> n"
+  have f0: "\<bar>a * a ^ n\<bar> = a * a ^ n"
+    using assms by auto
+  have f1: "\<bar>a ^ n\<bar> = a ^ n"
+    using assms by auto
+  have f1: "((1::\<real>) + real n) / ((a::\<real>) * (a::\<real>) ^ n) = ((n+1) / (a* n)) * (?f n)"
+    using a1 by auto
+  have f2: "((1::\<real>) + real n) / 1 \<le> (3::\<real>) * real n / (4/a)"
+    apply auto
+  have f3: "((1::\<real>) + real n) / ((2::\<real>) * (2::\<real>) ^ n) \<le> (3::\<real>) * real n / (2) / ((2::\<real>) * (2::\<real>) ^ n)"
+    apply (subst divide_right_mono[where c="((2::\<real>) * (2::\<real>) ^ n)"])
+    using f2 apply force
+    apply force
+    by simp
+  show "((1::\<real>) + real n) / \<bar>a * a ^ n\<bar> \<le> (3::\<real>) * real n / ((4::\<real>) * \<bar>a ^ n\<bar>)"
+    apply (simp only: f0)
+    apply (simp only: f1)
+    apply (auto)
+    using f3 by force
+qed
 *)
+
+lemma summable_1_2_power_n_t_n: 
+  "summable (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ (n) * ((real (t::\<nat>) + real n)))" (is "summable ?f")
+proof -
+  have f1: "(\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * ((real t + real n))) = 
+        (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * (real t)  + ((1::\<real>) / (2::\<real>)) ^ n * (real n))"
+    by (metis (mono_tags, opaque_lifting) mult_of_nat_commute of_nat_add ring_class.ring_distribs(2))
+
+  have f2: "(\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * real n) = (\<lambda>n::\<nat>. ((1::\<real>) / (2::\<real>)) ^ n * n)"
+    by simp
+  show "summable ?f"
+    apply (simp add: f1)
+     apply (subst summable_add)
+    apply (rule summable_mult2)
+    apply (rule summable_geometric)
+    apply simp
+    apply (subst summable_cong[where g = "(\<lambda>n::\<nat>. (n / (2::\<real>)^n))"])
+    apply (simp add: power_divide)
+    using summable_n_2_power_n apply blast
+    by simp
+qed
+
 end

--- a/probability/probabilistic_relations/utp_prob_rel_lattice.thy
+++ b/probability/probabilistic_relations/utp_prob_rel_lattice.thy
@@ -362,7 +362,7 @@ term "([] \<parallel> [a])"
 
 subsubsection \<open> Recursion \<close>
 alphabet time = 
-  t :: enat
+  t :: \<nat>
 
 text \<open>In UTP, @{text "\<mu>"} and @{text "\<nu>"} are the weakest and strongest fix point, but there are 
 @{term "gfp"} and @{term "lfp"} in Isabelle (see @{text "utp_pred.thy"}).

--- a/probability/probabilistic_relations/utp_prob_rel_lattice_laws.thy
+++ b/probability/probabilistic_relations/utp_prob_rel_lattice_laws.thy
@@ -3971,39 +3971,28 @@ next
     by force
 qed
 
-theorem decreasing_chain_limit_is_glb_all:
+theorem decreasing_chain_limit_is_glb':
   fixes f :: "nat \<Rightarrow> ('s\<^sub>1, 's\<^sub>2) prfun"
   assumes "decreasing_chain f"
-  assumes "\<F>\<S>\<^sub> f"
-  shows "\<forall>r > 0::real. \<exists>no::nat. \<forall>n \<ge> no.
-            \<forall>s s'. ureal2real (f n (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < r"
+  shows "\<forall>s s'. (\<lambda>n. ureal2real (f n (s, s'))) \<longlonglongrightarrow> (ureal2real (\<Sqinter>n::\<nat>. f n (s, s')))"
   apply (auto)
-proof -
-  fix r::"real"
-  assume a1: "0 < r"
-  have sup_upper: "\<forall>s s'. \<forall>n. ureal2real (f n (s, s')) \<ge> ureal2real (\<Sqinter>v::\<nat>. f n (s, s'))"
-    by (auto)
-  then have dist_equal: "\<forall>s s'. \<forall>n. \<bar>ureal2real (f n (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s'))\<bar> = 
-      ureal2real (f n (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s'))"
-    by (simp add: Inf_lower ureal2real_mono)
-  have limit_is_glb: "\<forall>s s'. (\<lambda>n. ureal2real (f n (s, s'))) \<longlonglongrightarrow> (ureal2real (\<Sqinter>n::\<nat>. f n (s, s')))"
-    by (simp add: assms decreasing_chain_limit_is_glb)
-  then have limit_is_glb_def: "\<forall>s s'. (\<exists>no::\<nat>. \<forall>n\<ge>no. norm (ureal2real (f n (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s'))) < r)"
-    using LIMSEQ_iff by (metis a1)
-  then have limit_is_glb_def': "\<forall>s s'. \<exists>no::nat. \<forall>n \<ge> no. ureal2real (f n (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < r"
-    by (simp add: dist_equal)
+  by (simp add: assms decreasing_chain_limit_is_glb)
 
-\<comment> \<open>The infimum of @{text "f"} is less than its initial value @{text "f 0"} and the difference is at 
-  least @{text "r"}. Therefore, a unique number @{text "no+1"} must exist such that @{text "f (no+1)"}
-  inside the supreme minus @{text "r"} and @{text "f no"} outside the supreme minus @{text "r"}.
-\<close>
-  let ?P_less_inf = "\<lambda>s s'. ((ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < ureal2real (f 0 (s, s'))) \<and> 
-      (ureal2real (f 0 (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s'))) \<ge> r)"
-  let ?P_mu_no = "\<lambda>s s'. \<lambda>no. (ureal2real (f (no+1) (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < r \<and> 
-      ureal2real (f no (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) \<ge> r)"
-\<comment> \<open>The uniqueness is proved. \<close>
-  have f_larger_supreme_unique_no: 
-   "\<forall>s s'. ?P_less_inf s s' \<longrightarrow> (\<exists>!no::nat. ?P_mu_no s s' no)"
+theorem decreasing_chain_limit_is_glb'':
+  fixes f :: "nat \<Rightarrow> ('s\<^sub>1, 's\<^sub>2) prfun"
+  assumes "decreasing_chain f"
+  shows "\<forall>s. (\<lambda>n. ureal2real (f n s)) \<longlonglongrightarrow> (ureal2real (\<Sqinter>n::\<nat>. f n s))"
+  apply (auto)
+  by (simp add: assms decreasing_chain_limit_is_glb')
+
+lemma prfun_dec_less_inf_unique_no:
+  fixes f :: "nat \<Rightarrow> ('s\<^sub>1, 's\<^sub>2) prfun"
+  assumes f_dec: "decreasing_chain f"
+  assumes r_pos: "0 < (r::\<real>)"
+  shows "\<forall>s s'. ((ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < ureal2real (f 0 (s, s'))) \<and> 
+      (ureal2real (f 0 (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s'))) \<ge> r) \<longrightarrow> 
+          (\<exists>!no::nat. (ureal2real (f (no+1) (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < r \<and> 
+      ureal2real (f no (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) \<ge> r))"
     apply (auto)
     defer
     apply (smt (verit, best) assms(1) decreasing_chain_antitone le_fun_def nle_le not_less_eq_eq ureal2real_mono)
@@ -4011,6 +4000,18 @@ proof -
     fix s s'
     assume a11: "ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < ureal2real (f (0::\<nat>) (s, s'))"
     assume a12: "r \<le> ureal2real (f (0::\<nat>) (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s'))"
+    have sup_upper: "\<forall>s s'. \<forall>n. ureal2real (f n (s, s')) \<ge> ureal2real (\<Sqinter>v::\<nat>. f n (s, s'))"
+    by (auto)
+    then have dist_equal: "\<forall>s s'. \<forall>n. \<bar>ureal2real (f n (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s'))\<bar> = 
+        ureal2real (f n (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s'))"
+      by (simp add: Inf_lower ureal2real_mono)
+    have limit_is_glb: "\<forall>s s'. (\<lambda>n. ureal2real (f n (s, s'))) \<longlonglongrightarrow> (ureal2real (\<Sqinter>n::\<nat>. f n (s, s')))"
+      by (simp add: assms decreasing_chain_limit_is_glb)
+    then have limit_is_glb_def: "\<forall>s s'. (\<exists>no::\<nat>. \<forall>n\<ge>no. norm (ureal2real (f n (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s'))) < r)"
+      using LIMSEQ_iff by (metis r_pos)
+    then have limit_is_glb_def': "\<forall>s s'. \<exists>no::nat. \<forall>n \<ge> no. ureal2real (f n (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < r"
+      by (simp add: dist_equal)
+
     show "\<exists>no::\<nat>.
           ureal2real (f (Suc no) (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < r \<and>
           r \<le> ureal2real (f no (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s'))"
@@ -4039,16 +4040,54 @@ proof -
     qed
   qed
 
-\<comment> \<open>If @{text "f n"} is constant or @{text "f 0"} is inside the infimum minus @{text "r"}, then for 
-  any number, the distance between @{text "f n"} and the infimum is less than @{text "r"}.\<close>
-  have f_const_or_larger_dist_universal: "\<forall>s s'. 
+lemma prfun_dec_const_or_lower_dist_universal:
+  fixes f :: "nat \<Rightarrow> ('s\<^sub>1, 's\<^sub>2) prfun"
+  assumes "decreasing_chain f"
+  assumes r_pos: "0 < (r::\<real>)"
+  shows "\<forall>s s'. 
       ((ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) = ureal2real (f 0 (s, s'))) \<or>
       (ureal2real (f 0 (s, s'))) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < r)
       \<longrightarrow>
       (\<forall>no. (ureal2real (f no (s, s'))) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < r)"
     apply (auto)
-    apply (smt (verit, ccfv_threshold) Sup.SUP_cong a1 assms(1) decreasing_chain_inf_eq_f0_constant ureal2real_eq)
+    apply (smt (verit, ccfv_threshold) Sup.SUP_cong r_pos assms(1) decreasing_chain_inf_eq_f0_constant ureal2real_eq)
     by (smt (verit, ccfv_SIG) assms(1) decreasing_chain_antitone le_fun_def less_eq_nat.simps(1) ureal2real_mono)
+
+theorem decreasing_chain_limit_is_glb_all:
+  fixes f :: "nat \<Rightarrow> ('s\<^sub>1, 's\<^sub>2) prfun"
+  assumes "decreasing_chain f"
+  assumes "\<F>\<S>\<^sub> f"
+  shows "\<forall>r > 0::real. \<exists>no::nat. \<forall>n \<ge> no.
+            \<forall>s s'. ureal2real (f n (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < r"
+  apply (auto)
+proof -
+  fix r::"real"
+  assume a1: "0 < r"
+  have inf_lower: "\<forall>s s'. \<forall>n. ureal2real (f n (s, s')) \<ge> ureal2real (\<Sqinter>v::\<nat>. f n (s, s'))"
+    by (auto)
+
+\<comment> \<open>The infimum of @{text "f"} is less than its initial value @{text "f 0"} and the difference is at 
+  least @{text "r"}. Therefore, a unique number @{text "no+1"} must exist such that @{text "f (no+1)"}
+  inside the supreme minus @{text "r"} and @{text "f no"} outside the supreme minus @{text "r"}.
+\<close>
+  let ?P_less_inf = "\<lambda>s s'. ((ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < ureal2real (f 0 (s, s'))) \<and> 
+      (ureal2real (f 0 (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s'))) \<ge> r)"
+  let ?P_mu_no = "\<lambda>s s'. \<lambda>no. (ureal2real (f (no+1) (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < r \<and> 
+      ureal2real (f no (s, s')) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) \<ge> r)"
+\<comment> \<open>The uniqueness is proved. \<close>
+  have f_lower_infimum_unique_no: 
+   "\<forall>s s'. ?P_less_inf s s' \<longrightarrow> (\<exists>!no::nat. ?P_mu_no s s' no)"
+    apply (rule prfun_dec_less_inf_unique_no)
+    by (simp add: assms(1) a1)+
+
+\<comment> \<open>If @{text "f n"} is constant or @{text "f 0"} is inside the infimum minus @{text "r"}, then for 
+  any number, the distance between @{text "f n"} and the infimum is less than @{text "r"}.\<close>
+  have f_const_or_lower_dist_universal: "\<forall>s s'. 
+      ((ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) = ureal2real (f 0 (s, s'))) \<or>
+      (ureal2real (f 0 (s, s'))) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < r)
+      \<longrightarrow>
+      (\<forall>no. (ureal2real (f no (s, s'))) - ureal2real (\<Sqinter>n::\<nat>. f n (s, s')) < r)"
+    using prfun_dec_const_or_lower_dist_universal a1 assms(1) by blast
 
   let ?mu_no_set = "{THE no. ?P_mu_no s s' no | s s'. ?P_less_inf s s'}"
 \<comment> \<open>We use another form @{text "?mu_no_set1"} in order to prove it is finite more conveniently using 
@@ -4117,7 +4156,7 @@ any number @{text "n \<ge> no"}, the distance between @{text "f n"} and the supr
       then have "n \<ge> 0"
         by blast
       then show ?thesis
-        using True f_const_or_larger_dist_universal by fastforce
+        using True f_const_or_lower_dist_universal by fastforce
     next
       case False
       then have max_leq_n: "(Max {uu::\<nat>. \<exists>(s::'s\<^sub>1) s'::'s\<^sub>2.
@@ -4134,7 +4173,7 @@ any number @{text "n \<ge> no"}, the distance between @{text "f n"} and the supr
         using max_leq_n by (meson Nat.le_diff_conv2 add_leE)
       have P_mu_no: "?P_mu_no s s' (THE no::\<nat>. ?P_mu_no s s' no)"
         apply (rule theI')
-        using False a1 f_larger_supreme_unique_no by auto
+        using False a1 f_lower_infimum_unique_no by auto
       have "ureal2real (f ((THE no::\<nat>. ?P_mu_no s s' no) + (1::\<nat>)) (s, s')) \<ge> ureal2real (f n (s,s'))"
         using mu_no_le_n 
         by (smt (verit, best) Nat.le_diff_conv2 add_leD2 assms(1) decreasing_chain_antitone le_fun_def max_leq_n ureal2real_mono)
@@ -4503,6 +4542,12 @@ lemma iterate_decreasing_chain:
     (is "decreasing_chain ?C")
   apply (simp add: decreasing_chain_def)
   by (simp add: assms iterate_decreasing2)
+
+lemma iterate_decreasing_chain_1:
+  assumes "is_final_distribution (rvfun_of_prfun (P::('s, 's) prfun))"
+  shows "decreasing_chain (\<lambda>n. \<F> b P (iterate n b P 1\<^sub>p))"
+  by (simp add: loopfunc_monoE assms decreasing_chain_def iterate_decreasing2)
+
 
 subsubsection \<open> Supreme \<close>
 lemma sup_iterate_not_zero_strict_increasing:
@@ -5420,6 +5465,10 @@ proof -
     using f1 f2 f3 f4 by presburger 
 qed
 
+lemma inf_iterate_subset_eq':
+  "(\<Sqinter>n::nat. \<F> b P (iterate n b P 1\<^sub>p)) = (\<Sqinter>n::nat. (iterate n b P 1\<^sub>p))"
+  using inf_iterate_subset_eq by force
+
 lemma inf_iterate_continuous':
   assumes "is_final_distribution (rvfun_of_prfun (P::('s, 's) prfun))"
   assumes "\<F>\<S>\<^sub> (\<lambda>n. iterate n b P 1\<^sub>p)"
@@ -5468,6 +5517,303 @@ theorem inf_iterate_continuous:
   apply (simp add: assms(1)) 
   using assms(2) apply auto[1]
   using inf_iterate_suc inf_iterate_subset_eq by metis
+
+theorem inf_iterate_continuous_finite_final':
+  assumes "is_final_distribution (rvfun_of_prfun (P::('s, 's) prfun))"
+  assumes P_finite_fin: "\<forall>s. finite {s'. (P (s, s') > 0)}"
+  shows "\<F> b P (\<Sqinter>n::nat. iterate n b P 1\<^sub>p) = (\<Sqinter>n::nat. \<F> b P (iterate n b P 1\<^sub>p))" (is "?LHS = ?RHS")
+proof -
+  (* *)
+  let ?I = "\<lambda>s n. ((iterate n b P 1\<^sub>p) s)"
+  (* *)
+  let ?Idiff = "(\<lambda>s n. (?I s (n+1) - ?I s n))"
+
+  let ?f = "\<lambda>n. \<F> b P (iterate n b P 1\<^sub>p)"
+
+  have iterate_seq_lim_RHS: "\<forall>s. (\<lambda>n. ureal2real (?f n s)) \<longlonglongrightarrow> (ureal2real (\<Sqinter>n::\<nat>. ?f n s))"
+    apply (subst decreasing_chain_limit_is_glb'')
+    by (simp add: assms iterate_decreasing_chain_1)+
+
+  (* To prove LHS is the limit of ?f *)
+  have iterate_seq_lim_LHS: "\<forall>s. (\<lambda>n::nat. ureal2real (?f n s)) \<longlonglongrightarrow> (ureal2real (?LHS s))"
+    apply (rule allI)
+    apply (subst LIMSEQ_iff)
+    apply (auto)
+  proof -
+    fix a::'s and ba::'s and r::\<real>
+    assume a1: "0 < r"
+
+    have norm_1: "\<forall>n. \<bar>ureal2real (\<F> b P (iter\<^sub>p n b P 1\<^sub>p) (a, ba)) - ureal2real (\<F> b P (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p) (a, ba))\<bar>  
+      = ureal2real (\<F> b P (iter\<^sub>p n b P 1\<^sub>p) (a, ba)) - ureal2real (\<F> b P (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p) (a, ba))"
+      apply (subst abs_of_nonneg)
+      apply (auto)
+      apply (rule ureal2real_mono)
+      using loopfunc_monoE by (metis INF_lower2 UNIV_I assms(1) le_funE order_eq_refl)
+    have norm_3: "\<forall>n. ureal2real (\<F> b P (iter\<^sub>p n b P 1\<^sub>p) (a, ba)) - ureal2real (\<F> b P (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p) (a, ba)) 
+      = (\<lbrakk>b\<rbrakk>\<^sub>\<I>) (a, ba) * ureal2real ((P ; (iter\<^sub>p n b P 1\<^sub>p - (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p))) (a, ba))"
+      apply (subst loopfunc_minus_distr')
+      using assms apply auto[1]
+      apply (meson is_prob_final_prob ureal_is_prob)
+      apply (simp add: is_prob_final_prob ureal_is_prob)
+      apply (meson INF_lower UNIV_I)
+      by simp
+
+    show "\<exists>no::\<nat>. \<forall>n::\<nat>. no \<le> n \<longrightarrow> 
+      \<bar>ureal2real (\<F> b P (iter\<^sub>p n b P 1\<^sub>p) (a, ba)) - ureal2real (\<F> b P (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p) (a, ba))\<bar> < r"
+      apply (simp add: norm_1)
+      apply (simp add: norm_3)
+    proof (cases "(\<lbrakk>b\<rbrakk>\<^sub>\<I>) (a, ba) = 0")
+      case True
+      then show "\<exists>no::\<nat>. \<forall>n::\<nat>. no \<le> n \<longrightarrow> (\<lbrakk>b\<rbrakk>\<^sub>\<I>) (a, ba) * ureal2real ((P ; iter\<^sub>p n b P 1\<^sub>p - (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p)) (a, ba)) < r"
+        by (simp add: a1)
+    next
+      case False
+      then have f1: "(\<lbrakk>b\<rbrakk>\<^sub>\<I>) (a, ba) = 1"
+        by (smt (verit, best) SEXP_def iverson_bracket_def)
+
+      have lim: "\<forall>v\<^sub>0. (\<lambda>n. ureal2real (iter\<^sub>p n b P 1\<^sub>p (v\<^sub>0, ba))) \<longlonglongrightarrow> ureal2real ((\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p) (v\<^sub>0, ba))"
+        apply (auto)
+        proof -
+          fix v\<^sub>0 :: 's
+          show "(\<lambda>n. ureal2real (iter\<^sub>p n b P 1\<^sub>p (v\<^sub>0, ba))) \<longlonglongrightarrow> ureal2real (\<Sqinter>f\<in>range (\<lambda>n. iter\<^sub>p n b P 1\<^sub>p). f (v\<^sub>0, ba))"
+          proof -
+            have "\<And>p f N. (\<Sqinter>f\<in>f ` N. (f (p::'s \<times> 's)::ureal)) = (\<Sqinter>n\<in>N. f (n::\<nat>) p)"
+              by (metis INF_apply Inf_apply)
+            then show ?thesis
+              by (metis assms(1) decreasing_chain_limit_is_glb iterate_decreasing_chain)
+          qed
+        qed
+
+      have epsilon_def: "\<forall>v\<^sub>0. \<forall>\<epsilon>>0. \<exists>N. \<forall>n \<ge> N. norm( (ureal2real (iter\<^sub>p n b P 1\<^sub>p (v\<^sub>0, ba)) - ureal2real ((\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p) (v\<^sub>0, ba)))) < \<epsilon>"
+        apply (rule allI)
+        apply (rule allI)
+        apply (rule impI)
+        apply (subst LIMSEQ_D)
+        using lim apply blast
+        by simp+
+
+      let ?fdiff' = "\<lambda>n v\<^sub>0::'s. ureal2real (iter\<^sub>p n b P 1\<^sub>p (v\<^sub>0, ba)) - ureal2real ((\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p) (v\<^sub>0, ba))"
+      have epsilon_def': "\<forall>v\<^sub>0. \<forall>\<epsilon>>0. \<exists>N. \<forall>n \<ge> N. ?fdiff' n v\<^sub>0 < \<epsilon>"
+        using epsilon_def abs_minus_commute by (smt (verit, del_insts) abs_ge_self real_norm_def)
+
+      let ?fdiff = "\<lambda>n v\<^sub>0::'s. ureal2real (((iter\<^sub>p n b P 1\<^sub>p) (v\<^sub>0, ba) - (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p) (v\<^sub>0, ba)))"
+      have epsilon_def'': "\<forall>v\<^sub>0. \<forall>\<epsilon>>0. \<exists>N. \<forall>n \<ge> N. ?fdiff n v\<^sub>0 < \<epsilon>"
+        apply (subst ureal2real_distr)
+        apply (simp add: Inf_lower)
+        using epsilon_def' by blast
+
+      have P_final_reachable: "\<exists>s'. P (a, s') > 0"
+        by (simp add: prfun_final_reachable assms) 
+
+      have P_card: "\<exists>N. N > 0 \<and> N = card {s'. (P (a, s') > 0)}"
+        apply (rule_tac x = "card {s'. (P (a, s') > 0)}" in exI)
+        apply (auto)
+        using P_final_reachable P_finite_fin card_gt_0_iff by blast
+
+      obtain card_P where P_N: "card_P > 0 \<and> card_P = card {s'. (P (a, s') > 0)}" 
+        using P_finite_fin P_card by blast
+
+      have inc: "decreasing_chain (\<lambda>n. iter\<^sub>p n b P 1\<^sub>p)"
+        using assms(1) iterate_decreasing_chain by blast
+
+      have r_card_P: "r/card_P > 0"
+        using P_N a1 divide_pos_pos of_nat_0_less_iff by blast
+    
+      let ?f1 = "\<lambda>n. iter\<^sub>p n b P 1\<^sub>p"
+      let ?P_less_inf = "\<lambda>s s'. ((ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, s')) < ureal2real (?f1 0 (s, s'))) \<and> 
+            (ureal2real (?f1 0 (s, s')) - ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, s'))) \<ge> r/card_P)"
+      let ?P_mu_no = "\<lambda>s s'. \<lambda>no. (ureal2real (?f1 (no+1) (s, s')) - ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, s')) < r/card_P \<and> 
+          ureal2real (?f1 no (s, s')) - ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, s')) \<ge> r/card_P)"
+      \<comment> \<open>The uniqueness is proved. \<close>
+      have f_lower_infimum_unique_no: 
+       "\<forall>s s'. ?P_less_inf s s' \<longrightarrow> (\<exists>!no::nat. ?P_mu_no s s' no)"
+        apply (rule prfun_dec_less_inf_unique_no)
+        by (simp add: inc r_card_P)+
+
+      \<comment> \<open>If @{text "f n"} is constant or @{text "f 0"} is inside the supreme minus @{text "r"}, then for 
+      any number, the distance between @{text "f n"} and the supreme is less than @{text "r"}.\<close>
+      have f_const_or_lower_dist_universal: "\<forall>s s'. 
+          ((ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, s')) = ureal2real (?f1 0 (s, s'))) \<or>
+          (ureal2real (?f1 0 (s, s')) - ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, s'))) < r/card_P)
+          \<longrightarrow>
+          (\<forall>no. ureal2real (?f1 no (s, s')) - ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, s')) < r/card_P)"
+        using prfun_dec_const_or_lower_dist_universal by (smt (verit, del_insts) le_fun_def 
+            linorder_not_less linorder_not_less r_card_P ureal2real_distr ureal2real_eq 
+            ureal2real_mono_strict ureal_minus_larger_zero ureal_plus_minus_cancel ureal_top_greatest' 
+            utp_prob_rel_lattice.iterate.simps(1))
+
+      let ?mu_no_set = "{THE no. ?P_mu_no s ba no | s. ?P_less_inf s ba \<and> s \<in> {s'::'s. (0::ureal) < P (a, s')}}"
+      obtain no where P_no:
+        "no = (Max ?mu_no_set + 1)"
+        by blast
+
+      have finite_no: "finite  {uu::\<nat>. \<exists>s::'s \<in> {s'::'s. (0::ureal) < P (a, s')}.
+         uu = (THE no::\<nat>. ?P_mu_no s ba no)}"
+        apply (subst finite_Collect_bex)
+        apply (simp add: P_finite_fin)
+        by simp
+      have finite_no': "finite ?mu_no_set"
+        apply (rule rev_finite_subset[where B = "{THE no. ?P_mu_no s ba no | s. s \<in> {s'::'s. (0::ureal) < P (a, s')}}"])
+        using finite_no apply (smt (verit, best) Collect_cong)
+        by blast
+  
+      have exist_NN: "\<exists>no::\<nat>. \<forall>n\<ge>no. \<forall>s \<in> {s'::'s. (0::ureal) < P (a, s')}. (ureal2real (?f1 n (s, ba)) - ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, ba))) < r/card_P"
+        apply (rule_tac x = "no" in exI)
+        apply (auto)
+        apply (simp add: P_no)
+      proof -
+        fix n::"\<nat>" and s::"'s"
+        assume a11:  "Suc (Max {uu::\<nat>.  \<exists>s::'s.
+                    uu =
+                    (THE no::\<nat>.
+                        ureal2real (\<F> b P (iter\<^sub>p no b P 1\<^sub>p) (s, ba)) - ureal2real (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p (s, ba)) < r / real card_P \<and>
+                        r / real card_P \<le> ureal2real (iter\<^sub>p no b P 1\<^sub>p (s, ba)) - ureal2real (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p (s, ba))) \<and>
+                    ureal2real (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p (s, ba)) < ureal2real (1\<^sub>p (s, ba)) \<and>
+                    r / real card_P \<le> ureal2real (1\<^sub>p (s, ba)) - ureal2real (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p (s, ba)) \<and> (0::ureal) < P (a, s)})
+          \<le> n"
+        assume a12: "(0::ureal) < P (a, s)"
+        show "ureal2real (iter\<^sub>p n b P 1\<^sub>p (s, ba)) - ureal2real (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p (s, ba)) < r / real card_P"
+
+        proof (cases "ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, ba)) = ureal2real (?f1 0 (s, ba)) \<or> 
+           \<not> r / real card_P \<le> ureal2real (?f1 (0::\<nat>) (s, ba) - ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, ba)))")
+          case True
+          then have "n \<ge> 0"
+            by blast
+          then show ?thesis
+            proof -
+              have "(\<Sqinter>n. iter\<^sub>p n b P 1\<^sub>p (s, ba)) \<le> iter\<^sub>p 0 b P 1\<^sub>p (s, ba)"
+                by (meson INF_lower2 UNIV_I dual_order.refl)
+              then show ?thesis
+                using True f_const_or_lower_dist_universal ureal2real_distr ureal2rereal_inverse by fastforce
+            qed
+        next
+           case False
+           then have False': "((ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, ba)) < ureal2real (?f1 0 (s, ba))) \<and> 
+              (ureal2real (?f1 0 (s, ba)) - ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, ba))) \<ge> r/card_P)"
+              by (smt (verit, ccfv_threshold) nle_le r_card_P ureal2real_distr ureal2rereal_inverse ureal_minus_larger_zero)
+           have max_leq_n: "Max {uu::\<nat>.
+                 \<exists>s::'s.
+                    uu =
+                    (THE no::\<nat>. ?P_mu_no s ba no) \<and>
+                    ureal2real (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p (s, ba)) < ureal2real (1\<^sub>p (s, ba)) \<and>
+                    r / real card_P \<le> ureal2real (1\<^sub>p (s, ba)) - ureal2real (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p (s, ba)) \<and> (0::ureal) < P (a, s)} + 1 \<le> n"
+             apply (simp add: iterate_suc[symmetric])
+             using SUP_cong a11 by force
+          then have mu_no_in: "(THE no::\<nat>. ?P_mu_no s ba no) \<in> ?mu_no_set"
+            apply (subst mem_Collect_eq)
+            apply (rule_tac x="s" in exI)
+            apply (rule conjI)
+            apply force
+            using False a12 r_card_P 
+            by (smt (verit) mem_Collect_eq nle_le ureal2real_distr ureal2rereal_inverse ureal_minus_larger_zero)
+          have ff: "\<forall>s. (s \<in> {s'::'s. (0::ureal) < P (a::'s, s')}) = ((0::ureal) < P (a, s))"
+            by simp
+          have mu_no_le_n: "(THE no::\<nat>. ?P_mu_no s ba no) \<le> n - 1"
+            apply (rule max_bounded_e[where A = "?mu_no_set"])
+            using mu_no_in apply meson
+            using mu_no_in apply blast
+            using finite_no' apply blast
+            apply (simp add: ff)
+            using max_leq_n a11 by linarith
+          have P_mu_no: "?P_mu_no s ba (THE no::\<nat>. ?P_mu_no s ba no)"
+            apply (rule theI')
+            apply (subst f_lower_infimum_unique_no)
+            using False' apply blast
+            by simp
+          have no_mono: "((THE no::\<nat>. ?P_mu_no s ba no) + (1::\<nat>)) \<le> n"
+            using mu_no_le_n max_leq_n by linarith
+          have "ureal2real (?f1 ((THE no::\<nat>. ?P_mu_no s ba no) + (1::\<nat>)) (s, ba)) \<ge> ureal2real (?f1 n (s,ba))"
+            apply (rule ureal2real_mono)
+            using no_mono iterate_decreasing2 by (smt (verit, best) assms(1) le_fun_def)
+          then show ?thesis
+            using P_mu_no by linarith
+        qed
+      qed
+
+      obtain NN where P_NN: "\<forall>n::\<nat>\<ge>NN. \<forall>s \<in> {s'::'s. (0::ureal) < P (a, s')}. (ureal2real (?f1 n (s, ba)) - ureal2real (\<Sqinter>n::\<nat>. ?f1 n (s, ba))) < r/card_P"
+        using exist_NN by blast
+
+      have P_NN': "\<forall>n::\<nat>\<ge>NN. \<forall>s \<in> {s'::'s. (0::ureal) < P (a, s')}. (ureal2real ((?f1 n (s, ba)) - (\<Sqinter>n::\<nat>. ?f1 n (s, ba)))) < r/card_P"
+        using P_NN by (smt (verit, del_insts) INF_lower UNIV_I ureal2real_distr)
+
+      let ?f = "\<lambda>n s::'s. ureal2real (P (a, s)) * ureal2real ((?f1 n (s, ba)) - (\<Sqinter>n::\<nat>. ?f1 n) (s, ba))"
+      have discard_impossible: "\<forall>n. (\<Sum>\<^sub>\<infinity>v\<^sub>0::'s. ?f n v\<^sub>0) = (\<Sum>\<^sub>\<infinity>v\<^sub>0::'s\<in>{s'. P (a, s') > 0}. ?f n v\<^sub>0)"
+        apply (rule allI)
+        apply (subst infsum_cong_neutral[where T = "UNIV" and S = "{s'. P (a, s') > 0}" and f = "?f n" and g = "?f n"])
+        apply (metis Diff_iff diff_self linorder_not_le mem_Collect_eq mult_zero_left nle_le ureal2real_distr ureal2real_mono_strict ureal_lower_bound ureal_minus_larger_zero)
+        apply blast
+        by (simp)+
+
+      have P_remove_leq: "\<forall>n. (\<Sum>\<^sub>\<infinity>v\<^sub>0::'s\<in>{s'. P (a, s') > 0}. ?f n v\<^sub>0) \<le> 
+        (\<Sum>\<^sub>\<infinity>s::'s\<in>{s'. P (a, s') > 0}. ureal2real ((?f1 n (s, ba)) - (\<Sqinter>n::\<nat>. ?f1 n) (s, ba)))"
+        apply (rule allI)
+        apply (rule infsum_mono_neutral)
+        using P_N card_ge_0_finite summable_on_finite apply blast
+        using P_card card_ge_0_finite summable_on_finite apply blast
+        apply (smt (verit, best) INF_apply Inf.INF_cong mult.commute mult_right_le_one_le ureal_lower_bound ureal_upper_bound)
+        apply blast
+        by fastforce
+
+      have P_remove_le: "\<exists>no::\<nat>. \<forall>n\<ge> no. (\<Sum>\<^sub>\<infinity>v\<^sub>0::'s\<in>{s'. P (a, s') > 0}. ureal2real ((iter\<^sub>p n b P 1\<^sub>p) (v\<^sub>0, ba) - (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p) (v\<^sub>0, ba))) 
+                                        < (\<Sum>\<^sub>\<infinity>v\<^sub>0::'s\<in>{s'. P (a, s') > 0}. r/card_P)"
+        apply (rule_tac x = "NN" in exI, rule allI, rule impI)
+        apply (subst infsum_finite)
+        using P_card card_ge_0_finite apply blast
+        apply (subst infsum_finite)
+        using P_card card_ge_0_finite apply blast
+        apply (subst sum_strict_mono)
+        using P_finite_fin apply fastforce
+        using P_N card_gt_0_iff apply blast
+        apply (metis INF_apply P_NN')
+        by simp
+
+      have P_r: "(\<Sum>\<^sub>\<infinity>v\<^sub>0::'s\<in>{s'. P (a, s') > 0}. r/card_P) = r"
+        apply (subst infsum_constant)
+        using P_finite_fin apply blast
+        using P_N by force
+
+      have P_le_r: "\<exists>no::\<nat>. \<forall>n\<ge> no. (\<Sum>\<^sub>\<infinity>v\<^sub>0::'s\<in>{s'. 0 < P (a, s')}. ureal2real ( (iter\<^sub>p n b P 1\<^sub>p) (v\<^sub>0, ba) - (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p) (v\<^sub>0, ba))) < r"
+        using P_remove_le P_r by simp
+(*
+      obtain NNN where P_NNN: "\<forall>n\<ge> NNN. (\<Sum>\<^sub>\<infinity>v\<^sub>0::'s\<in>{s'. P (a, s') > 0}. ureal2real ( (iter\<^sub>p n b P 1\<^sub>p) (v\<^sub>0, ba) - (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p) (v\<^sub>0, ba))) < r"
+        using P_le_r by blast
+*)
+      have f_eq: "\<forall>v\<^sub>0. (\<Sqinter>f::'s \<times> 's \<Rightarrow> ureal\<in>range (\<lambda>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p). f (v\<^sub>0, ba)) = (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p) (v\<^sub>0, ba)"
+        by force
+
+      show "\<exists>no::\<nat>. \<forall>n::\<nat>. no \<le> n \<longrightarrow> (\<lbrakk>b\<rbrakk>\<^sub>\<I>) (a, ba) * ureal2real ((P ; iter\<^sub>p n b P 1\<^sub>p - (\<Sqinter>n::\<nat>. iter\<^sub>p n b P 1\<^sub>p)) (a, ba)) < r" 
+        apply (simp add: f1)
+        apply (simp add: pseqcomp_def prfun_of_rvfun_def)
+        apply (subst real2ureal_inverse)
+        apply (simp add: infsum_nonneg prfun_in_0_1' subst_app_def)
+        apply (pred_auto)
+        apply (subst rvfun_infsum_pcomp_lessthan_1_subdist')
+        using assms is_dist_subdist apply blast
+        using ureal_is_prob apply blast
+        apply simp
+        apply (pred_auto)
+        apply (simp add: rvfun_of_prfun_def)
+        apply (simp only: f_eq)
+        apply (subst discard_impossible)
+        using P_le_r P_remove_leq by (smt (verit, del_insts))
+    qed
+  qed
+
+  have "\<forall>s. (ureal2real (?LHS s)) = (ureal2real (\<Sqinter>n::\<nat>. ?f n s))"
+    using LIMSEQ_unique iterate_seq_lim_LHS iterate_seq_lim_RHS by blast
+
+  then have "\<forall>s. (?LHS s) = ?RHS s"
+    using ureal2real_eq by (smt (verit) INF_apply Inf.INF_cong)
+  then show ?thesis
+    by blast
+qed
+
+theorem inf_iterate_continuous_finite_final:
+  assumes "is_final_distribution (rvfun_of_prfun (P::('s, 's) prfun))"
+  assumes P_finite_fin: "\<forall>s. finite {s'. (P (s, s') > 0)}"
+  shows "\<F> b P (\<Sqinter>n::nat. iterate n b P 1\<^sub>p) = (\<Sqinter>n::nat. (iterate n b P 1\<^sub>p))" (is "?LHS = ?RHS")
+  using inf_iterate_continuous_finite_final' 
+  by (metis P_finite_fin assms(1) inf_iterate_subset_eq')
 
 subsubsection \<open> Kleene fixed-point theorem \<close>
 lemma fp_between_lfp_gfp:
@@ -5551,6 +5897,30 @@ theorem inf_continuous_gfp_iteration:
   apply (rule gfp_eqI)
   apply (simp add: loopfunc_mono assms)
   using assms inf_iterate_continuous apply blast
+  by (simp add: assms(1) fp_between_lfp_gfp(2))
+
+text \<open> 2. The greatest fixed point is calculated if the function @{text "\<F> b P"} is continuous 
+because of the calculated supreme @{text "\<Squnion>n::nat. iterate n b P 0\<^sub>p"}. \<close>
+theorem inf_continuous_gfp_iteration_inf:
+  assumes P_dist: "is_final_distribution (rvfun_of_prfun (P::('s, 's) prfun))"
+  assumes F_continuous: "\<F> b P (\<Sqinter>n::nat. (iterate n b P 1\<^sub>p)) = (\<Sqinter>n::nat. \<F> b P (iterate n b P 1\<^sub>p))"
+  shows "while\<^sub>p\<^sup>\<top> b do P od = (\<Sqinter>n::nat. (iterate n b P 1\<^sub>p))"
+  apply (simp add: pwhile_top_def)
+  apply (rule gfp_eqI)
+  apply (simp add: loopfunc_mono assms)
+  using assms inf_iterate_subset_eq apply force
+  by (simp add: assms(1) fp_between_lfp_gfp(2))
+
+text \<open> 3. The greatest fixed point is calculated if the function @{text "\<F> b P"} is continuous 
+because of the calculated supreme @{text "\<Squnion>n::nat. iterate n b P 0\<^sub>p"}.  \<close>
+theorem inf_continuous_gfp_iteration_finite_final:
+  assumes "is_final_distribution (rvfun_of_prfun (P::('s, 's) prfun))"
+  assumes P_finite_fin: "\<forall>s. finite {s'. (P (s, s') > 0)}"
+  shows "while\<^sub>p\<^sup>\<top> b do P od = (\<Sqinter>n::nat. (iterate n b P 1\<^sub>p))"
+  apply (simp add: pwhile_top_def)
+  apply (rule gfp_eqI)
+  apply (simp add: loopfunc_mono assms)
+  using assms inf_iterate_continuous_finite_final apply blast
   by (simp add: assms(1) fp_between_lfp_gfp(2))
 
 subsubsection \<open> Unique fixed point \<close>

--- a/probability/probabilistic_relations/utp_prob_rel_lattice_laws.thy
+++ b/probability/probabilistic_relations/utp_prob_rel_lattice_laws.thy
@@ -1918,6 +1918,16 @@ theorem prfun_seqcomp_left_one_point: "x := e ; P = prfun_of_rvfun (([ x\<^sup><
   apply (pred_auto)
   by (simp add: infsum_mult_singleton_left)
 
+(*
+theorem prfun_seqcomp_right_one_point: "P; x := e  = prfun_of_rvfun (([ x\<^sup>> \<leadsto> e\<^sup>< ] \<dagger> @(rvfun_of_prfun P)))\<^sub>e"
+  apply (simp add: pfun_defs expr_defs)
+  apply (subst rvfun_inverse)
+  apply (simp add: dist_defs expr_defs)
+  apply (rule HOL.arg_cong[where f="prfun_of_rvfun"])
+  apply (pred_auto)
+  apply (subst infsum_mult_singleton_right)
+*)
+
 lemma prfun_infsum_over_pair_subset_1:
   assumes "is_final_distribution (rvfun_of_prfun (P::'a prhfun))"
   shows "(\<Sum>\<^sub>\<infinity> (s::'a, v\<^sub>0::'a). rvfun_of_prfun P (s\<^sub>1, v\<^sub>0) * (if put\<^bsub>x\<^esub> v\<^sub>0 (e v\<^sub>0) = s then 1::\<real> else (0::\<real>))) = 1"


### PR DESCRIPTION
Proved a new unique fixed-point theorem that has a more general assumption, requiring every iteration won't produce the distribution with infinite states having positive probabilities (in other words, finite reachable states). This theorem entitles us to reason about expected runtime or termination time by using a time variable to count the number of iterations.

With the theorem, the time versions of the coin flip and the dice throw are proved.